### PR TITLE
fix: DMN table headers

### DIFF
--- a/Agent/Agent.Web/Views/Dmn/Index.cshtml
+++ b/Agent/Agent.Web/Views/Dmn/Index.cshtml
@@ -135,5 +135,5 @@
 </div>
 
 @section Scripts {
-    <script src="~/js/dmn-manager.js?v=2"></script>
+    <script src="~/js/dmn-manager.js?v=3"></script>
 }

--- a/Agent/Agent.Web/wwwroot/js/dmn-manager.js
+++ b/Agent/Agent.Web/wwwroot/js/dmn-manager.js
@@ -70,29 +70,33 @@ function displayDmnInfo(table) {
  * Build dynamic table headers based on inputs and outputs (excluding submissionId)
  */
 function buildTableHeaders(table) {
-    const headerRow = $('#rulesTable thead tr');
+  const headerRow = $('#rulesTable thead tr');
 
-    // Remove existing dynamic columns
-    headerRow.find('th:not(:first):not(:nth-child(2)):not(:last)').remove();
+  // Remove existing dynamic columns (keep #, Description, and Actions)
+  headerRow.find('th:not(:first-child):not(:nth-child(2)):not(:last-child)').remove();
 
-    // Add input columns (excluding submissionId)
-    let visibleInputCount = 0;
-    table.inputs.forEach(input => {
-        const label = input.label || input.expression || 'Input';
-        // Skip submissionId input
-        if (label.toLowerCase() === 'submissionid') {
-            return;
-        }
-        headerRow.find('th:nth-child(2)').after(`<th class="text-dark bg-light">Input: ${label}</th>`);
-        visibleInputCount++;
-    });
+  // Filter inputs, excluding submissionId
+  const visibleInputs = table.inputs.filter(input => {
+    const label = (input.label || input.expression || '').toLowerCase();
+    return label !== 'submissionid';
+  });
 
-    // Add output columns (after inputs and description)
-    const lastInputIndex = 2 + visibleInputCount;
-    table.outputs.forEach(output => {
-        const label = output.label || output.name || 'Output';
-        headerRow.find(`th:nth-child(${lastInputIndex})`).after(`<th class="text-dark bg-light">Output: ${label}</th>`);
-    });
+  // Use a moving anchor so insertion order is preserved (not reversed)
+  let anchor = headerRow.find('th:nth-child(2)');
+  visibleInputs.forEach(input => {
+    const label = input.label || input.expression || 'Input';
+    const th = $(`<th class="text-dark bg-light">Input: ${label}</th>`);
+    anchor.after(th);
+    anchor = th; // advance anchor to the newly inserted th
+  });
+
+  // Insert output headers after all inputs, also with a moving anchor
+  table.outputs.forEach(output => {
+    const label = output.label || output.name || 'Output';
+    const th = $(`<th class="text-dark bg-light">Output: ${label}</th>`);
+    anchor.after(th);
+    anchor = th;
+  });
 }
 
 /**


### PR DESCRIPTION
### :hammer_and_wrench: Pull Request
<!-- # Delete content types that don't apply to your pull request -->
🦋 Bug Fix

#### Description:
Currently, the DMN table headers are not correctly rendering. For example, I have put a value as input: project, but the DMn table shows that value as input:user. This PR fixed that problem

<img width="1389" height="839" alt="Screenshot 2026-03-23 at 14 16 28" src="https://github.com/user-attachments/assets/f272ec43-daad-4cb8-8cae-ca673b4eb4b3" />
<img width="1389" height="839" alt="Screenshot 2026-03-23 at 14 16 36" src="https://github.com/user-attachments/assets/8639ef40-ac92-4a6f-9f62-1a55d5b3ddcf" />


## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :paperclip: Have commits been checked for accidental file inclusions?  
