### PR TITLE
fix: Make Serilog level as Env Var

### DIFF
--- a/Agent/Agent.Api/Program.cs
+++ b/Agent/Agent.Api/Program.cs
@@ -29,6 +29,7 @@ using FiveSafesTes.Core.Models.Settings;
 using FiveSafesTes.Core.Models.ViewModels;
 using FiveSafesTes.Core.Rabbit;
 using FiveSafesTes.Core.Services;
+using Serilog.Events;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -314,10 +315,13 @@ Serilog.ILogger CreateSerilogLogger(ConfigurationManager configuration, IWebHost
 {
     var seqServerUrl = configuration["Serilog:SeqServerUrl"];
     var seqApiKey = configuration["Serilog:SeqApiKey"];
-
+    var logLevelValue = configuration["Serilog:MinimumLevel:Default"];
+    var logLevel = Enum.TryParse<LogEventLevel>(logLevelValue, true, out var parsedLevel)
+      ? parsedLevel
+      : LogEventLevel.Information;
 
     return new LoggerConfiguration()
-        .MinimumLevel.Verbose()
+        .MinimumLevel.Is(logLevel)
         .Enrich.WithProperty("ApplicationContext", environment.ApplicationName)
         .Enrich.FromLogContext()
         .WriteTo.Console()

--- a/Agent/Agent.Api/appsettings.Development.json
+++ b/Agent/Agent.Api/appsettings.Development.json
@@ -84,7 +84,7 @@
     "SeqServerUrl": "http://localhost:5341",
     "SeqApiKey": "",
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore.Model.Validation": "Error",

--- a/Agent/Agent.Api/appsettings.Development_Notts.json
+++ b/Agent/Agent.Api/appsettings.Development_Notts.json
@@ -82,7 +82,7 @@
     "SeqServerUrl": "http://localhost:5341",
     "SeqApiKey": "",
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore.Model.Validation": "Error",

--- a/Agent/Agent.Api/appsettings.json
+++ b/Agent/Agent.Api/appsettings.json
@@ -82,7 +82,7 @@
     "SeqServerUrl": "http://localhost:5341",
     "SeqApiKey": "",
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore.Model.Validation": "Error",

--- a/Agent/Agent.Web/Program.cs
+++ b/Agent/Agent.Web/Program.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json;
 using Microsoft.AspNetCore.DataProtection;
+using Serilog.Events;
 
 var builder = WebApplication.CreateBuilder(args);
 ConfigurationManager configuration = builder.Configuration;
@@ -387,9 +388,13 @@ Serilog.ILogger CreateSerilogLogger(ConfigurationManager configuration, IWebHost
 {
     var seqServerUrl = configuration["Serilog:SeqServerUrl"];
     var seqApiKey = configuration["Serilog:SeqApiKey"];
+    var logLevelValue = configuration["Serilog:MinimumLevel:Default"];
+    var logLevel = Enum.TryParse<LogEventLevel>(logLevelValue, true, out var parsedLevel)
+      ? parsedLevel
+      : LogEventLevel.Information;
 
     return new LoggerConfiguration()
-        .MinimumLevel.Verbose()
+        .MinimumLevel.Is(logLevel)
         .Enrich.WithProperty("ApplicationContext", environment.ApplicationName)
         .Enrich.FromLogContext()
         .WriteTo.Console()

--- a/Agent/Agent.Web/appsettings.Development.json
+++ b/Agent/Agent.Web/appsettings.Development.json
@@ -40,7 +40,7 @@
     "SeqServerUrl": "http://localhost:5341",
     "SeqApiKey": "",
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore.Model.Validation": "Error",

--- a/Agent/Agent.Web/appsettings.Development_Notts.json
+++ b/Agent/Agent.Web/appsettings.Development_Notts.json
@@ -38,7 +38,7 @@
     "SeqServerUrl": "http://localhost:5341",
     "SeqApiKey": "",
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore.Model.Validation": "Error",

--- a/Agent/Agent.Web/appsettings.json
+++ b/Agent/Agent.Web/appsettings.json
@@ -40,7 +40,7 @@
     "SeqServerUrl": "http://localhost:5341",
     "SeqApiKey": "",
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore.Model.Validation": "Error",

--- a/Credentials/Credentials.Camunda/Program.cs
+++ b/Credentials/Credentials.Camunda/Program.cs
@@ -5,6 +5,7 @@ using Zeebe.Client;
 using System.Reflection;
 using Zeebe.Client.Accelerator.Extensions;
 using Credentials.Camunda.Services;
+using Serilog.Events;
 
 var builder = WebApplication.CreateBuilder(args);
 var configuration = GetConfiguration();
@@ -19,7 +20,11 @@ Serilog.ILogger CreateSerilogLogger(IConfiguration configuration)
 {
     var seqServerUrl = configuration["Serilog:SeqServerUrl"];
     var seqApiKey = configuration["Serilog:SeqApiKey"];
-
+    var logLevelValue = configuration["Serilog:MinimumLevel:Default"];
+    var logLevel = Enum.TryParse<LogEventLevel>(logLevelValue, true, out var parsedLevel)
+      ? parsedLevel
+      : LogEventLevel.Information;
+    
     if (seqServerUrl == null)
     {
         Log.Error("seqServerUrl is null");
@@ -27,7 +32,7 @@ Serilog.ILogger CreateSerilogLogger(IConfiguration configuration)
     }
 
     return new LoggerConfiguration()
-    .MinimumLevel.Verbose()
+      .MinimumLevel.Is(logLevel)
     .Enrich.WithProperty("ApplicationContext", AppName)
     .Enrich.FromLogContext()
     .WriteTo.Console()

--- a/Credentials/Credentials.Camunda/appsettings.json
+++ b/Credentials/Credentials.Camunda/appsettings.json
@@ -10,7 +10,7 @@
     "SeqServerUrl": "http://localhost:5341",
     "SeqApiKey": "",
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore.Model.Validation": "Error",

--- a/Submission/Submission.Api/Program.cs
+++ b/Submission/Submission.Api/Program.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using NETCore.MailKit.Extensions;
 using NETCore.MailKit.Infrastructure.Internal;
 using Microsoft.AspNetCore.DataProtection;
+using Serilog.Events;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -378,11 +379,15 @@ Serilog.ILogger CreateSerilogLogger(ConfigurationManager configuration, IWebHost
 {
     var seqServerUrl = configuration["Serilog:SeqServerUrl"];
     var seqApiKey = configuration["Serilog:SeqApiKey"];
+    var logLevelValue = configuration["Serilog:MinimumLevel:Default"];
+    var logLevel = Enum.TryParse<LogEventLevel>(logLevelValue, true, out var parsedLevel)
+        ? parsedLevel
+        : LogEventLevel.Information;
 
 
 
     return new LoggerConfiguration()
-    .MinimumLevel.Verbose()
+    .MinimumLevel.Is(logLevel)
     .Enrich.WithProperty("ApplicationContext", environment.ApplicationName)
     .Enrich.FromLogContext()
     .WriteTo.Console()

--- a/Submission/Submission.Api/appsettings.Development.json
+++ b/Submission/Submission.Api/appsettings.Development.json
@@ -50,7 +50,7 @@
     "SeqServerUrl": "http://localhost:5341",
     "SeqApiKey": "",
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore.Model.Validation": "Error",

--- a/Submission/Submission.Api/appsettings.Development_Notts.json
+++ b/Submission/Submission.Api/appsettings.Development_Notts.json
@@ -48,7 +48,7 @@
     "SeqServerUrl": "http://localhost:5341",
     "SeqApiKey": "",
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore.Model.Validation": "Error",

--- a/Submission/Submission.Api/appsettings.json
+++ b/Submission/Submission.Api/appsettings.json
@@ -49,7 +49,7 @@
     "SeqServerUrl": "http://localhost:5341",
     "SeqApiKey": "",
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore.Model.Validation": "Error",

--- a/Submission/Submission.Web/Program.cs
+++ b/Submission/Submission.Web/Program.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 using Submission.Web.Models;
 using Submission.Web.Services;
 using Microsoft.AspNetCore.DataProtection;
+using Serilog.Events;
 
 var builder = WebApplication.CreateBuilder(args);
 IdentityModelEventSource.ShowPII = true;
@@ -426,8 +427,12 @@ Serilog.ILogger CreateSerilogLogger(ConfigurationManager configuration, IWebHost
 {
     var seqServerUrl = configuration["Serilog:SeqServerUrl"];
     var seqApiKey = configuration["Serilog:SeqApiKey"];
+    var logLevelValue = configuration["Serilog:MinimumLevel:Default"];
+    var logLevel = Enum.TryParse<LogEventLevel>(logLevelValue, true, out var parsedLevel)
+      ? parsedLevel
+      : LogEventLevel.Information;
     return new LoggerConfiguration()
-        .MinimumLevel.Verbose()
+        .MinimumLevel.Is(logLevel)
         .Enrich.WithProperty("ApplicationContext", environment.ApplicationName)
         .Enrich.FromLogContext()
         .WriteTo.Console()

--- a/Submission/Submission.Web/appsettings.Development.json
+++ b/Submission/Submission.Web/appsettings.Development.json
@@ -40,7 +40,7 @@
     "SeqServerUrl": "http://localhost:5341",
     "SeqApiKey": "",
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore.Model.Validation": "Error",

--- a/Submission/Submission.Web/appsettings.Development_Notts.json
+++ b/Submission/Submission.Web/appsettings.Development_Notts.json
@@ -39,7 +39,7 @@
     "SeqServerUrl": "http://localhost:5341",
     "SeqApiKey": "",
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore.Model.Validation": "Error",

--- a/Submission/Submission.Web/appsettings.json
+++ b/Submission/Submission.Web/appsettings.json
@@ -40,7 +40,7 @@
     "SeqServerUrl": "http://localhost:5341",
     "SeqApiKey": "",
     "MinimumLevel": {
-      "Default": "Verbose",
+      "Default": "Information",
       "Override": {
         "Microsoft": "Warning",
         "Microsoft.EntityFrameworkCore.Model.Validation": "Error",


### PR DESCRIPTION
### :hammer_and_wrench: Pull Request
<!-- # Delete content types that don't apply to your pull request -->
🦋 Bug Fix

#### Description:
Currently, `Verbose` is set as the minimum level for logging, which is not recommended by Serilog docs, especially for production. This PR make the default for the log's minimum level as Information, and if we want to change this, we can still update it by using an env var.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :paperclip: Have commits been checked for accidental file inclusions?  
