### PR TITLE
fix: add restriction to console logs write

### DIFF
--- a/Agent/Agent.Api/Program.cs
+++ b/Agent/Agent.Api/Program.cs
@@ -324,7 +324,7 @@ Serilog.ILogger CreateSerilogLogger(ConfigurationManager configuration, IWebHost
         .MinimumLevel.Is(logLevel)
         .Enrich.WithProperty("ApplicationContext", environment.ApplicationName)
         .Enrich.FromLogContext()
-        .WriteTo.Console()
+        .WriteTo.Console(restrictedToMinimumLevel: logLevel)
         .WriteTo.Seq(seqServerUrl, apiKey: seqApiKey)
         .ReadFrom.Configuration(configuration)
         .CreateLogger();

--- a/Agent/Agent.Web/Program.cs
+++ b/Agent/Agent.Web/Program.cs
@@ -397,7 +397,7 @@ Serilog.ILogger CreateSerilogLogger(ConfigurationManager configuration, IWebHost
         .MinimumLevel.Is(logLevel)
         .Enrich.WithProperty("ApplicationContext", environment.ApplicationName)
         .Enrich.FromLogContext()
-        .WriteTo.Console()
+        .WriteTo.Console(restrictedToMinimumLevel: logLevel)
         .WriteTo.Seq(seqServerUrl, apiKey: seqApiKey)
         .ReadFrom.Configuration(configuration)
         .CreateLogger();

--- a/Credentials/Credentials.Camunda/Program.cs
+++ b/Credentials/Credentials.Camunda/Program.cs
@@ -35,7 +35,7 @@ Serilog.ILogger CreateSerilogLogger(IConfiguration configuration)
       .MinimumLevel.Is(logLevel)
     .Enrich.WithProperty("ApplicationContext", AppName)
     .Enrich.FromLogContext()
-    .WriteTo.Console()
+    .WriteTo.Console(restrictedToMinimumLevel: logLevel)
     .WriteTo.Seq(seqServerUrl, apiKey: seqApiKey)
     .ReadFrom.Configuration(configuration)
     .CreateLogger();

--- a/Submission/Submission.Api/Program.cs
+++ b/Submission/Submission.Api/Program.cs
@@ -390,7 +390,7 @@ Serilog.ILogger CreateSerilogLogger(ConfigurationManager configuration, IWebHost
     .MinimumLevel.Is(logLevel)
     .Enrich.WithProperty("ApplicationContext", environment.ApplicationName)
     .Enrich.FromLogContext()
-    .WriteTo.Console()
+    .WriteTo.Console(restrictedToMinimumLevel: logLevel)
     .WriteTo.Seq(seqServerUrl, apiKey: seqApiKey)
     .ReadFrom.Configuration(configuration)
     .CreateLogger();

--- a/Submission/Submission.Web/Program.cs
+++ b/Submission/Submission.Web/Program.cs
@@ -435,7 +435,7 @@ Serilog.ILogger CreateSerilogLogger(ConfigurationManager configuration, IWebHost
         .MinimumLevel.Is(logLevel)
         .Enrich.WithProperty("ApplicationContext", environment.ApplicationName)
         .Enrich.FromLogContext()
-        .WriteTo.Console()
+        .WriteTo.Console(restrictedToMinimumLevel: logLevel)
         .WriteTo.Seq(seqServerUrl, apiKey: seqApiKey)
         .ReadFrom.Configuration(configuration)
         .CreateLogger();


### PR DESCRIPTION
### :hammer_and_wrench: Pull Request
<!-- # Delete content types that don't apply to your pull request -->

🦋 Bug Fix

#### Description:
The last PR reduced the logs on SEQ but not on the logs file in the Docker container system, so this PR restricted the Write to console to be at the same level as SEQ.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :paperclip: Have commits been checked for accidental file inclusions?  
