### PR TITLE
feat: Prioritise Vault configuration over appsettings

### DIFF
--- a/Agent/Agent.Api/Agent.Api.csproj
+++ b/Agent/Agent.Api/Agent.Api.csproj
@@ -64,6 +64,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />
     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
+    <PackageReference Include="VaultSharp" Version="1.17.5.1" />
     <PackageReference Include="zb-client-accelerator" Version="2.1.13" />
   </ItemGroup>
 

--- a/Agent/Agent.Api/Controllers/ConfigurationController.cs
+++ b/Agent/Agent.Api/Controllers/ConfigurationController.cs
@@ -1,0 +1,22 @@
+using Agent.Api.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Agent.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ConfigurationController : Controller
+{
+    private readonly IConfigurationService _configurationService;
+
+    public ConfigurationController(IConfigurationService configService)
+    {
+        _configurationService = configService;
+    }
+
+    [HttpPost("AddConfigurationToVault/{json}")]
+    public async Task AddConfigurationToVault(string json)
+    {
+        await _configurationService.AddConfigurationToVault(json);
+    }
+}

--- a/Agent/Agent.Api/Models/VaultConfigSettings.cs
+++ b/Agent/Agent.Api/Models/VaultConfigSettings.cs
@@ -2,11 +2,9 @@ namespace Agent.Api.Models;
 
 public class VaultConfigSettings
 {
+    public int TREId { get; set; }
     public string TREName { get; set; }
     public string SubmissionURL { get; set; }
     public string KeycloakRealmSettingURL { get; set; }
-    public string Username { get; set; }
     public string JWT { get; set; }
-    public string Password { get; set; }
-    public string VaultConfigPath { get; set; }
 }

--- a/Agent/Agent.Api/Models/VaultConfigSettings.cs
+++ b/Agent/Agent.Api/Models/VaultConfigSettings.cs
@@ -1,0 +1,12 @@
+namespace Agent.Api.Models;
+
+public class VaultConfigSettings
+{
+    public string TREName { get; set; }
+    public string SubmissionURL { get; set; }
+    public string KeycloakRealmSettingURL { get; set; }
+    public string Username { get; set; }
+    public string JWT { get; set; }
+    public string Password { get; set; }
+    public string VaultConfigPath { get; set; }
+}

--- a/Agent/Agent.Api/Program.cs
+++ b/Agent/Agent.Api/Program.cs
@@ -140,10 +140,6 @@ var AgentSettings = new AgentSettings();
 configuration.Bind(nameof(AgentSettings), AgentSettings);
 builder.Services.AddSingleton(AgentSettings);
 
-var VaultSettings = new VaultSettings();
-configuration.Bind(nameof(VaultSettings), VaultSettings);
-builder.Services.AddSingleton(VaultSettings);
-
 builder.Services.AddFeatureManagement(
     builder.Configuration.GetSection("Features"));
 

--- a/Agent/Agent.Api/Program.cs
+++ b/Agent/Agent.Api/Program.cs
@@ -144,6 +144,10 @@ var VaultConfigSettings = new VaultConfigSettings();
 configuration.Bind(nameof(VaultConfigSettings), VaultConfigSettings);
 builder.Services.AddSingleton(VaultConfigSettings);
 
+var VaultSettings = new VaultSettings();
+configuration.Bind(nameof(VaultSettings), VaultSettings);
+builder.Services.AddSingleton(VaultSettings);
+
 builder.Services.AddFeatureManagement(
     builder.Configuration.GetSection("Features"));
 
@@ -172,6 +176,7 @@ builder.Services.AddScoped<IDoAgentWork, DoAgentWork>();
 builder.Services.AddScoped<IHasuraService, HasuraService>();
 builder.Services.AddScoped<IHasuraAuthenticationService, HasuraAuthenticationService>();
 builder.Services.AddScoped<IKeyCloakService, KeyCloakService>();
+builder.Services.AddScoped<IConfigurationService, ConfigurationService>();
 
 var TVP = new TokenValidationParameters
 {
@@ -305,8 +310,7 @@ using (var scope = app.Services.CreateScope())
     var vaultClientSettings = new VaultClientSettings(options.BaseUrl, authMethod);
     IVaultClient vaultClient = new VaultClient(vaultClientSettings);
 
-    string configPath = configuration["VaultConfigSettings:VaultConfigPath"];
-    configuration.AddVault(vaultClient, configPath, options.SecretEngine, TimeSpan.FromSeconds(30));
+    configuration.AddVault(vaultClient, options.VaultConfigPath, options.SecretEngine, TimeSpan.FromSeconds(30));
 }
 
 

--- a/Agent/Agent.Api/Program.cs
+++ b/Agent/Agent.Api/Program.cs
@@ -30,6 +30,9 @@ using FiveSafesTes.Core.Models.ViewModels;
 using FiveSafesTes.Core.Rabbit;
 using FiveSafesTes.Core.Services;
 using Serilog.Events;
+using VaultSharp;
+using VaultSharp.V1.AuthMethods;
+using VaultSharp.V1.AuthMethods.Token;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -292,6 +295,13 @@ using (var scope = app.Services.CreateScope())
         initialiser.SeedAllInOneData(configuration["DemoModeDefaultP"]);
     }
     credDb.Database.Migrate();
+
+    var options = app.Services.GetRequiredService<IOptions<VaultSettings>>().Value;
+    IAuthMethodInfo authMethod = new TokenAuthMethodInfo(options.Token);
+    var vaultClientSettings = new VaultClientSettings(options.BaseUrl, authMethod);
+    IVaultClient vaultClient = new VaultClient(vaultClientSettings);
+
+    configuration.AddVault(vaultClient, "config", options.SecretEngine, TimeSpan.FromSeconds(30));
 }
 
 

--- a/Agent/Agent.Api/Program.cs
+++ b/Agent/Agent.Api/Program.cs
@@ -140,6 +140,10 @@ var AgentSettings = new AgentSettings();
 configuration.Bind(nameof(AgentSettings), AgentSettings);
 builder.Services.AddSingleton(AgentSettings);
 
+var VaultConfigSettings = new VaultConfigSettings();
+configuration.Bind(nameof(VaultConfigSettings), VaultConfigSettings);
+builder.Services.AddSingleton(VaultConfigSettings);
+
 builder.Services.AddFeatureManagement(
     builder.Configuration.GetSection("Features"));
 
@@ -301,7 +305,8 @@ using (var scope = app.Services.CreateScope())
     var vaultClientSettings = new VaultClientSettings(options.BaseUrl, authMethod);
     IVaultClient vaultClient = new VaultClient(vaultClientSettings);
 
-    configuration.AddVault(vaultClient, "config", options.SecretEngine, TimeSpan.FromSeconds(30));
+    string configPath = configuration["VaultConfigSettings:VaultConfigPath"];
+    configuration.AddVault(vaultClient, configPath, options.SecretEngine, TimeSpan.FromSeconds(30));
 }
 
 

--- a/Agent/Agent.Api/Program.cs
+++ b/Agent/Agent.Api/Program.cs
@@ -140,10 +140,6 @@ var AgentSettings = new AgentSettings();
 configuration.Bind(nameof(AgentSettings), AgentSettings);
 builder.Services.AddSingleton(AgentSettings);
 
-var VaultConfigSettings = new VaultConfigSettings();
-configuration.Bind(nameof(VaultConfigSettings), VaultConfigSettings);
-builder.Services.AddSingleton(VaultConfigSettings);
-
 var VaultSettings = new VaultSettings();
 configuration.Bind(nameof(VaultSettings), VaultSettings);
 builder.Services.AddSingleton(VaultSettings);
@@ -364,6 +360,8 @@ void AddVaultServices(WebApplicationBuilder builder, ConfigurationManager config
     //Configure Vault settings
     builder.Services.Configure<VaultSettings>(
         configuration.GetSection("VaultSettings"));
+
+    builder.Services.Configure<VaultConfigSettings>(configuration.GetSection("VaultConfigSettings"));
 
     // Register HttpClient for Vault service
     builder.Services.AddHttpClient<IVaultCredentialsService, VaultCredentialsService>((sp, client) =>

--- a/Agent/Agent.Api/Services/ConfigurationService.cs
+++ b/Agent/Agent.Api/Services/ConfigurationService.cs
@@ -14,6 +14,7 @@ public class ConfigurationService : IConfigurationService
     private readonly IVaultClient _vaultClient;
 
     public readonly VaultSettings _vaultSettings;
+    // IOptionsMonitor used to retrieve latest values from vault at runtime.
     public readonly IOptionsMonitor<VaultConfigSettings> _configSettings;  
 
     public ConfigurationService(IOptions<VaultSettings> vaultSettings, IOptionsMonitor<VaultConfigSettings> configSettings)

--- a/Agent/Agent.Api/Services/ConfigurationService.cs
+++ b/Agent/Agent.Api/Services/ConfigurationService.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+using Agent.Api.Models;
+using FiveSafesTes.Core.Models.Settings;
+using VaultSharp;
+using VaultSharp.V1.AuthMethods;
+using VaultSharp.V1.AuthMethods.Token;
+
+namespace Agent.Api.Services;
+
+public class ConfigurationService : IConfigurationService
+{
+    private readonly IVaultClient _vaultClient;
+    public readonly VaultSettings _vaultSettings;
+
+    public ConfigurationService(VaultSettings vaultSettings)
+    {
+        _vaultSettings = vaultSettings;
+
+        IAuthMethodInfo authMethod = new TokenAuthMethodInfo(_vaultSettings.Token);
+        VaultClientSettings vaultClientSettings = new(_vaultSettings.BaseUrl, authMethod);
+        _vaultClient = new VaultClient(vaultClientSettings);
+    }
+
+    public async Task AddConfigurationToVault(string json)
+    {
+        Dictionary<string, object>? config = DeserializeConfigJsonToDictionary(json);
+
+        if (config != null)
+        {
+
+            await _vaultClient.V1.Secrets.KeyValue.V2.WriteSecretAsync(
+                path: _vaultSettings.VaultConfigPath,
+                data: config,
+                mountPoint: _vaultSettings.SecretEngine
+            );
+        }
+        else
+        {
+            // invalid json format error
+        }
+    }
+
+    public Dictionary<string, object>? DeserializeConfigJsonToDictionary(string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    public VaultConfigSettings? DeserializeConfigJson(string json)
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<VaultConfigSettings>(json);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+}

--- a/Agent/Agent.Api/Services/ConfigurationService.cs
+++ b/Agent/Agent.Api/Services/ConfigurationService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Agent.Api.Models;
 using FiveSafesTes.Core.Models.Settings;
+using Microsoft.Extensions.Options;
 using VaultSharp;
 using VaultSharp.V1.AuthMethods;
 using VaultSharp.V1.AuthMethods.Token;
@@ -11,23 +12,29 @@ public class ConfigurationService : IConfigurationService
 {
     private readonly IVaultClient _vaultClient;
     public readonly VaultSettings _vaultSettings;
+    // IOptionsMonitor allows us to retrieve the most recent configuration values at runtime.
+    public readonly IOptionsMonitor<VaultConfigSettings> _configSettings;  
 
-    public ConfigurationService(VaultSettings vaultSettings)
+    public ConfigurationService(VaultSettings vaultSettings, IOptionsMonitor<VaultConfigSettings> configSettings)
     {
         _vaultSettings = vaultSettings;
+        _configSettings = configSettings;
 
         IAuthMethodInfo authMethod = new TokenAuthMethodInfo(_vaultSettings.Token);
         VaultClientSettings vaultClientSettings = new(_vaultSettings.BaseUrl, authMethod);
         _vaultClient = new VaultClient(vaultClientSettings);
     }
 
+    /// <summary>
+    /// Extract configuration values from a given json string and add or update the corresponding values in Vault.
+    /// </summary>
+    /// <param name="json">The json containing the configuration values we want to add to Vault.</param>
     public async Task AddConfigurationToVault(string json)
     {
         Dictionary<string, object>? config = DeserializeConfigJsonToDictionary(json);
 
         if (config != null)
         {
-
             await _vaultClient.V1.Secrets.KeyValue.V2.WriteSecretAsync(
                 path: _vaultSettings.VaultConfigPath,
                 data: config,
@@ -36,10 +43,15 @@ public class ConfigurationService : IConfigurationService
         }
         else
         {
-            // invalid json format error
+            // invalid json format
         }
     }
 
+    /// <summary>
+    /// Deserialize our json configuration into a dictionary. 
+    /// </summary>
+    /// <param name="json">The json containing our configuration values.</param>
+    /// <returns>A dictionary containing the configuration, or null if the input json is invalid.</returns>
     public Dictionary<string, object>? DeserializeConfigJsonToDictionary(string json)
     {
         try
@@ -52,6 +64,11 @@ public class ConfigurationService : IConfigurationService
         }
     }
 
+    /// <summary>
+    /// Deserialize our json configuration into the vault configuration model. 
+    /// </summary>
+    /// <param name="json">The json containing our configuration values.</param>
+    /// <returns>A model representing our vault configuration, or null if the input json is invalid.</returns>
     public VaultConfigSettings? DeserializeConfigJson(string json)
     {
         try

--- a/Agent/Agent.Api/Services/ConfigurationService.cs
+++ b/Agent/Agent.Api/Services/ConfigurationService.cs
@@ -5,19 +5,20 @@ using Microsoft.Extensions.Options;
 using VaultSharp;
 using VaultSharp.V1.AuthMethods;
 using VaultSharp.V1.AuthMethods.Token;
+using static IdentityModel.ClaimComparer;
 
 namespace Agent.Api.Services;
 
 public class ConfigurationService : IConfigurationService
 {
     private readonly IVaultClient _vaultClient;
+
     public readonly VaultSettings _vaultSettings;
-    // IOptionsMonitor allows us to retrieve the most recent configuration values at runtime.
     public readonly IOptionsMonitor<VaultConfigSettings> _configSettings;  
 
-    public ConfigurationService(VaultSettings vaultSettings, IOptionsMonitor<VaultConfigSettings> configSettings)
+    public ConfigurationService(IOptions<VaultSettings> vaultSettings, IOptionsMonitor<VaultConfigSettings> configSettings)
     {
-        _vaultSettings = vaultSettings;
+        _vaultSettings = vaultSettings?.Value ?? throw new ArgumentNullException(nameof(vaultSettings));
         _configSettings = configSettings;
 
         IAuthMethodInfo authMethod = new TokenAuthMethodInfo(_vaultSettings.Token);

--- a/Agent/Agent.Api/Services/IConfigurationService.cs
+++ b/Agent/Agent.Api/Services/IConfigurationService.cs
@@ -1,0 +1,10 @@
+using Agent.Api.Models;
+
+namespace Agent.Api.Services;
+
+public interface IConfigurationService
+{
+    Dictionary<string, object>? DeserializeConfigJsonToDictionary(string json);
+    VaultConfigSettings? DeserializeConfigJson(string json);
+    Task AddConfigurationToVault(string json);
+}

--- a/Agent/Agent.Api/VaultConfigurationProvider.cs
+++ b/Agent/Agent.Api/VaultConfigurationProvider.cs
@@ -75,7 +75,6 @@ public class VaultConfigurationSource : IConfigurationSource
 
     public IConfigurationProvider Build(IConfigurationBuilder builder)
     {
-        // note: this method is called automatically by the configuration builder
         return new VaultConfigurationProvider(Client, Path, MountPoint, ReloadInterval);
     }
 }

--- a/Agent/Agent.Api/VaultConfigurationProvider.cs
+++ b/Agent/Agent.Api/VaultConfigurationProvider.cs
@@ -1,0 +1,81 @@
+using VaultSharp;
+using VaultSharp.V1.Commons;
+
+namespace Agent.Api;
+
+public class VaultConfigurationProvider: ConfigurationProvider, IDisposable
+{
+    private readonly Timer _timer;
+    private readonly IVaultClient _vaultClient;
+    private readonly string _path;
+    private readonly string _mountPoint;
+
+    public VaultConfigurationProvider(IVaultClient vaultClient, string path, string mountPoint, TimeSpan reloadInterval)
+    {
+        _vaultClient = vaultClient;
+        _path = path;
+        _mountPoint = mountPoint;
+
+        Load();
+
+        // Check vault for changes in values at the given interval.
+        _timer = new Timer(async _ => await LoadAsync(), null, reloadInterval, reloadInterval);
+    }
+
+    private async Task LoadAsync()
+    {
+        Secret<SecretData> secret = await _vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(_path, mountPoint: _mountPoint);
+        IDictionary<string, object> data = secret.Data.Data;
+
+        Dictionary<string, string> newData = data.ToDictionary(k => k.Key, v => v.Value?.ToString());
+
+        // Do not reload if there are no changes to the values in vault.
+        if (Data.Count == newData.Count && !Data.Except(newData).Any())
+        {
+            Data = newData;
+            OnReload();
+        }
+    }
+
+    public override void Load()
+    {
+        LoadAsync().GetAwaiter().GetResult();
+    }
+
+    public void Dispose()
+    {
+        _timer?.Dispose();
+    }
+}
+
+/// <summary>
+/// Extend the configuration builder with the AddVault method, allowing us to register Vault as a configuration source.
+/// </summary>
+public static class VaultConfigurationExtensions
+{
+    public static IConfigurationBuilder AddVault(this IConfigurationBuilder builder, IVaultClient client, string path, string mountPoint, TimeSpan reloadInterval)
+    {
+        return builder.Add(new VaultConfigurationSource
+        {
+            Client = client,
+            Path = path,
+            MountPoint = mountPoint,
+            ReloadInterval = reloadInterval
+        });
+    }
+}
+
+public class VaultConfigurationSource : IConfigurationSource
+{
+    public IVaultClient Client { get; set; }
+    public string Path { get; set; }
+    public string MountPoint { get; set; }
+    public TimeSpan ReloadInterval { get; set; }
+
+
+    public IConfigurationProvider Build(IConfigurationBuilder builder)
+    {
+        // note: this method is called automatically by the configuration builder
+        return new VaultConfigurationProvider(Client, Path, MountPoint, ReloadInterval);
+    }
+}

--- a/Agent/Agent.Api/VaultConfigurationProvider.cs
+++ b/Agent/Agent.Api/VaultConfigurationProvider.cs
@@ -27,7 +27,7 @@ public class VaultConfigurationProvider: ConfigurationProvider, IDisposable
         Secret<SecretData> secret = await _vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(_path, mountPoint: _mountPoint);
         IDictionary<string, object> data = secret.Data.Data;
 
-        Dictionary<string, string> newData = data.ToDictionary(k => k.Key, v => v.Value?.ToString());
+        Dictionary<string, string?> newData = data.ToDictionary(k => $"{nameof(Models.VaultConfigSettings)}:{k.Key}", v => v.Value?.ToString());
 
         // Do not reload if there are no changes to the values in vault.
         if (Data.Count == newData.Count && !Data.Except(newData).Any())

--- a/Agent/Agent.Api/VaultConfigurationProvider.cs
+++ b/Agent/Agent.Api/VaultConfigurationProvider.cs
@@ -30,7 +30,7 @@ public class VaultConfigurationProvider: ConfigurationProvider, IDisposable
         Dictionary<string, string?> newData = data.ToDictionary(k => $"{nameof(Models.VaultConfigSettings)}:{k.Key}", v => v.Value?.ToString());
 
         // Do not reload if there are no changes to the values in vault.
-        if (Data.Count == newData.Count && !Data.Except(newData).Any())
+        if (!Data.SequenceEqual(newData))
         {
             Data = newData;
             OnReload();

--- a/Agent/Agent.Api/appsettings.json
+++ b/Agent/Agent.Api/appsettings.json
@@ -156,7 +156,8 @@
     "TimeoutSeconds": 30,
     "SecretEngine": "secret",
     "EnableRetry": true,
-    "MaxRetryAttempts": 3
+    "MaxRetryAttempts": 3,
+    "VaultConfigPath": "config"
   },
   "DmnPath": {
     "Path": "../../Credentials/Credentials.Models/ProcessModels"
@@ -172,8 +173,5 @@
       "PollingTimeoutInMilliseconds": 1000,
       "RetryTimeoutInMilliseconds": 1000
     }
-  },
-  "VaultConfigSettings": {
-    "VaultConfigPath": "config"
   }
 }

--- a/Agent/Agent.Api/appsettings.json
+++ b/Agent/Agent.Api/appsettings.json
@@ -172,5 +172,8 @@
       "PollingTimeoutInMilliseconds": 1000,
       "RetryTimeoutInMilliseconds": 1000
     }
+  },
+  "VaultConfigSettings": {
+    "VaultConfigPath": "config"
   }
 }

--- a/Shared/FiveSafesTes.Core/Models/Settings/VaultSettings.cs
+++ b/Shared/FiveSafesTes.Core/Models/Settings/VaultSettings.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Shared/FiveSafesTes.Core/Models/Settings/VaultSettings.cs
+++ b/Shared/FiveSafesTes.Core/Models/Settings/VaultSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/Shared/FiveSafesTes.Core/Models/Settings/VaultSettings.cs
+++ b/Shared/FiveSafesTes.Core/Models/Settings/VaultSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,5 +14,6 @@ namespace FiveSafesTes.Core.Models.Settings
         public string SecretEngine { get; set; } = "secret"; // KV v2 engine name
         public bool EnableRetry { get; set; } = true;
         public int MaxRetryAttempts { get; set; } = 3;
+        public string VaultConfigPath { get; set; } = "config";
     }
 }


### PR DESCRIPTION
### :hammer_and_wrench: Pull Request
<!-- # Delete content types that don't apply to your pull request -->
✨ Feature
#### Description:
- Create a new Configuration Provider that pulls values from Vault. These values take precedence over those in appsettings.
- Create a service that can deserialise config json and add the extracted values to vault.
- Vault configuration is checked for updates at regular intervals at runtime.
- Add VaultSharp library to allow our configuration provider to talk to vault.
## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :paperclip: Have commits been checked for accidental file inclusions?  
