### PR TITLE
feat: Auto-create Keycloak service account when onboarding a TRE

### DIFF
--- a/Shared/FiveSafesTes.Core/Models/Tre.cs
+++ b/Shared/FiveSafesTes.Core/Models/Tre.cs
@@ -1,4 +1,4 @@
-﻿using FiveSafesTes.Core.Models.Helpers;
+using FiveSafesTes.Core.Models.Helpers;
 
 namespace FiveSafesTes.Core.Models
 {
@@ -10,6 +10,7 @@ namespace FiveSafesTes.Core.Models
 
         public DateTime LastHeartBeatReceived { get; set; }
         public string AdminUsername { get; set; }
+        public string? KeycloakClientId { get; set; }
 
         public string About {  get; set; }
         public string FormData { get; set; }

--- a/Submission/Submission.Api/Controllers/TreController.cs
+++ b/Submission/Submission.Api/Controllers/TreController.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Serilog;
@@ -8,6 +8,8 @@ using FiveSafesTes.Core.Models.ViewModels;
 using Microsoft.EntityFrameworkCore;
 using Submission.Api.Repositories.DbContexts;
 using Submission.Api.Services;
+using Submission.Api.Services.Contract;
+using FiveSafesTes.Core.Services;
 
 namespace Submission.Api.Controllers
 {
@@ -19,13 +21,18 @@ namespace Submission.Api.Controllers
     {
         private readonly ApplicationDbContext _DbContext;
         protected readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IKeycloakAdminService _keycloakAdminService;
+        private readonly IVaultCredentialsService _vaultCredentialsService;
 
 
-        public TreController(ApplicationDbContext applicationDbContext, IHttpContextAccessor httpContextAccessor)
+        public TreController(ApplicationDbContext applicationDbContext, IHttpContextAccessor httpContextAccessor,
+            IKeycloakAdminService keycloakAdminService, IVaultCredentialsService vaultCredentialsService)
         {
 
             _DbContext = applicationDbContext;
-            _httpContextAccessor= httpContextAccessor;
+            _httpContextAccessor = httpContextAccessor;
+            _keycloakAdminService = keycloakAdminService;
+            _vaultCredentialsService = vaultCredentialsService;
 
         }     
 
@@ -74,6 +81,33 @@ namespace Submission.Api.Controllers
                 }
                 await _DbContext.SaveChangesAsync();
                 await ControllerHelpers.AddAuditLog(logtype, null, null, tre, null, null, _httpContextAccessor, User, _DbContext);
+
+                if (logtype == LogType.AddTre && string.IsNullOrEmpty(tre.KeycloakClientId))
+                {
+                    try
+                    {
+                        var (clientUuid, clientId, clientSecret) = await _keycloakAdminService.CreateServiceAccountAsync(tre.Name);
+
+                        tre.KeycloakClientId = clientId;
+                        await _DbContext.SaveChangesAsync();
+
+                        await _vaultCredentialsService.AddCredentialAsync($"tre/{tre.Name.ToLower()}/keycloak",
+                            new Dictionary<string, object>
+                            {
+                                { "clientId", clientId },
+                                { "clientSecret", clientSecret },
+                                { "clientUuid", clientUuid }
+                            });
+
+                        Log.Information("{Function} Service account {ClientId} created and stored in Vault for TRE {TreName}",
+                            "SaveTre", clientId, tre.Name);
+                    }
+                    catch (Exception serviceAccountEx)
+                    {
+                        Log.Error(serviceAccountEx, "{Function} Failed to create service account for TRE {TreName}. TRE was saved but service account needs manual setup.",
+                            "SaveTre", tre.Name);
+                    }
+                }
 
                 return Ok(tre); 
             }

--- a/Submission/Submission.Api/Migrations/20260421091946_AddKeycloakClientIdToTre.Designer.cs
+++ b/Submission/Submission.Api/Migrations/20260421091946_AddKeycloakClientIdToTre.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Submission.Api.Repositories.DbContexts;
@@ -11,9 +12,11 @@ using Submission.Api.Repositories.DbContexts;
 namespace Submission.Api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260421091946_AddKeycloakClientIdToTre")]
+    partial class AddKeycloakClientIdToTre
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Submission/Submission.Api/Migrations/20260421091946_AddKeycloakClientIdToTre.cs
+++ b/Submission/Submission.Api/Migrations/20260421091946_AddKeycloakClientIdToTre.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Submission.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddKeycloakClientIdToTre : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "KeycloakClientId",
+                table: "Tres",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "KeycloakClientId",
+                table: "Tres");
+        }
+    }
+}

--- a/Submission/Submission.Api/Program.cs
+++ b/Submission/Submission.Api/Program.cs
@@ -408,6 +408,7 @@ void AddDependencies(WebApplicationBuilder builder, ConfigurationManager configu
     builder.Services.AddScoped<IKeycloakMinioUserService, KeycloakMinioUserService>();
     builder.Services.AddScoped<IKeycloakTokenApiHelper, KeycloakTokenApiHelper>();
     builder.Services.AddScoped<IKeyCloakService, KeyCloakService>();
+    builder.Services.AddScoped<IKeycloakAdminService, KeycloakAdminService>();
     builder.Services.AddScoped<IDareEmailService, DareEmailService>();
     
 

--- a/Submission/Submission.Api/Services/Contract/IKeycloakAdminService.cs
+++ b/Submission/Submission.Api/Services/Contract/IKeycloakAdminService.cs
@@ -1,0 +1,8 @@
+namespace Submission.Api.Services.Contract
+{
+    public interface IKeycloakAdminService
+    {
+        Task<(string clientUuid, string clientId, string clientSecret)> CreateServiceAccountAsync(string treName);
+        Task<bool> DeleteServiceAccountAsync(string clientUuid);
+    }
+}

--- a/Submission/Submission.Api/Services/KeycloakAdminService.cs
+++ b/Submission/Submission.Api/Services/KeycloakAdminService.cs
@@ -1,0 +1,207 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.RegularExpressions;
+using FiveSafesTes.Core.Models.Settings;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Serilog;
+using Submission.Api.Services.Contract;
+
+namespace Submission.Api.Services
+{
+    public class KeycloakAdminService : IKeycloakAdminService
+    {
+        private readonly SubmissionKeyCloakSettings _keycloakSettings;
+        private readonly IConfiguration _configuration;
+
+        public KeycloakAdminService(SubmissionKeyCloakSettings keycloakSettings, IConfiguration configuration)
+        {
+            _keycloakSettings = keycloakSettings;
+            _configuration = configuration;
+        }
+
+        public async Task<(string clientUuid, string clientId, string clientSecret)> CreateServiceAccountAsync(string treName)
+        {
+            var clientId = GenerateClientId(treName);
+            var adminToken = await GetAdminTokenAsync();
+
+            var clientUuid = await CreateClientAsync(adminToken, clientId, treName);
+            var clientSecret = await GetClientSecretAsync(adminToken, clientUuid);
+
+            Log.Information("{Function} Created service account {ClientId} for TRE {TreName}",
+                "CreateServiceAccountAsync", clientId, treName);
+
+            return (clientUuid, clientId, clientSecret);
+        }
+
+        public async Task<bool> DeleteServiceAccountAsync(string clientUuid)
+        {
+            var adminToken = await GetAdminTokenAsync();
+            var baseUrl = GetKeycloakBaseUrl();
+            var realm = _keycloakSettings.Realm;
+
+            using var client = new HttpClient(_keycloakSettings.getProxyHandler);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+            var url = $"{baseUrl}/admin/realms/{realm}/clients/{clientUuid}";
+            var response = await client.DeleteAsync(url);
+
+            if (response.IsSuccessStatusCode)
+            {
+                Log.Information("{Function} Deleted Keycloak client {ClientUuid}", "DeleteServiceAccountAsync", clientUuid);
+                return true;
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            Log.Error("{Function} Failed to delete client {ClientUuid}. Status: {Status}, Response: {Response}",
+                "DeleteServiceAccountAsync", clientUuid, response.StatusCode, content);
+            return false;
+        }
+
+        private async Task<string> GetAdminTokenAsync()
+        {
+            var baseUrl = GetKeycloakBaseUrl();
+            var adminUsername = _configuration["KeycloakAdmin:Username"];
+            var adminPassword = _configuration["KeycloakAdmin:Password"];
+
+            var url = $"{baseUrl}/realms/master/protocol/openid-connect/token";
+
+            using var client = new HttpClient(_keycloakSettings.getProxyHandler);
+            var tokenRequest = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                { "client_id", "admin-cli" },
+                { "username", adminUsername },
+                { "password", adminPassword },
+                { "grant_type", "password" }
+            });
+
+            var response = await client.PostAsync(url, tokenRequest);
+            var content = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                Log.Error("{Function} Failed to get admin token. Status: {Status}, Response: {Response}",
+                    "GetAdminTokenAsync", response.StatusCode, content);
+                throw new Exception($"Failed to get Keycloak admin token: {response.StatusCode}");
+            }
+
+            var tokenResponse = JObject.Parse(content);
+            return tokenResponse["access_token"]?.ToString()
+                ?? throw new Exception("Admin token response did not contain access_token");
+        }
+
+        private async Task<string> CreateClientAsync(string adminToken, string clientId, string treName)
+        {
+            var baseUrl = GetKeycloakBaseUrl();
+            var realm = _keycloakSettings.Realm;
+
+            using var client = new HttpClient(_keycloakSettings.getProxyHandler);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            var clientPayload = new
+            {
+                clientId = clientId,
+                name = $"TRE Agent - {treName}",
+                enabled = true,
+                protocol = "openid-connect",
+                publicClient = false,
+                serviceAccountsEnabled = true,
+                clientAuthenticatorType = "client-secret",
+                directAccessGrantsEnabled = false,
+                standardFlowEnabled = false
+            };
+
+            var json = JsonConvert.SerializeObject(clientPayload);
+            var url = $"{baseUrl}/admin/realms/{realm}/clients";
+
+            var response = await client.PostAsync(url, new StringContent(json, Encoding.UTF8, "application/json"));
+
+            if (response.StatusCode == System.Net.HttpStatusCode.Conflict)
+            {
+                Log.Warning("{Function} Client {ClientId} already exists, retrieving existing client",
+                    "CreateClientAsync", clientId);
+                return await GetClientUuidByClientIdAsync(adminToken, clientId);
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var content = await response.Content.ReadAsStringAsync();
+                Log.Error("{Function} Failed to create client {ClientId}. Status: {Status}, Response: {Response}",
+                    "CreateClientAsync", clientId, response.StatusCode, content);
+                throw new Exception($"Failed to create Keycloak client: {response.StatusCode} - {content}");
+            }
+
+            var locationHeader = response.Headers.Location?.ToString();
+            if (!string.IsNullOrEmpty(locationHeader))
+            {
+                return locationHeader.Split('/').Last();
+            }
+
+            return await GetClientUuidByClientIdAsync(adminToken, clientId);
+        }
+
+        private async Task<string> GetClientUuidByClientIdAsync(string adminToken, string clientId)
+        {
+            var baseUrl = GetKeycloakBaseUrl();
+            var realm = _keycloakSettings.Realm;
+
+            using var client = new HttpClient(_keycloakSettings.getProxyHandler);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+            var url = $"{baseUrl}/admin/realms/{realm}/clients?clientId={clientId}";
+            var response = await client.GetAsync(url);
+            var content = await response.Content.ReadAsStringAsync();
+
+            var clients = JArray.Parse(content);
+            if (clients.Count == 0)
+            {
+                throw new Exception($"Client {clientId} not found in Keycloak");
+            }
+
+            return clients[0]["id"]?.ToString()
+                ?? throw new Exception($"Client {clientId} found but has no UUID");
+        }
+
+        private async Task<string> GetClientSecretAsync(string adminToken, string clientUuid)
+        {
+            var baseUrl = GetKeycloakBaseUrl();
+            var realm = _keycloakSettings.Realm;
+
+            using var client = new HttpClient(_keycloakSettings.getProxyHandler);
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
+
+            var url = $"{baseUrl}/admin/realms/{realm}/clients/{clientUuid}/client-secret";
+            var response = await client.GetAsync(url);
+            var content = await response.Content.ReadAsStringAsync();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                Log.Error("{Function} Failed to get client secret for {ClientUuid}. Status: {Status}",
+                    "GetClientSecretAsync", clientUuid, response.StatusCode);
+                throw new Exception($"Failed to get client secret: {response.StatusCode}");
+            }
+
+            var secretResponse = JObject.Parse(content);
+            return secretResponse["value"]?.ToString()
+                ?? throw new Exception("Client secret response did not contain value");
+        }
+
+        private string GetKeycloakBaseUrl()
+        {
+            var baseUrl = _keycloakSettings.BaseUrl;
+            var realmSuffix = $"/realms/{_keycloakSettings.Realm}";
+            if (baseUrl.EndsWith(realmSuffix))
+            {
+                baseUrl = baseUrl.Substring(0, baseUrl.Length - realmSuffix.Length);
+            }
+            return baseUrl;
+        }
+
+        private static string GenerateClientId(string treName)
+        {
+            var slug = Regex.Replace(treName.ToLower().Trim(), @"[^a-z0-9]+", "-").Trim('-');
+            return $"tre-agent-{slug}";
+        }
+    }
+}

--- a/Submission/Submission.Api/appsettings.json
+++ b/Submission/Submission.Api/appsettings.json
@@ -89,5 +89,9 @@
     "SecretEngine": "secret",
     "EnableRetry": true,
     "MaxRetryAttempts": 3
+  },
+  "KeycloakAdmin": {
+    "Username": "admin",
+    "Password": "admin"
   }
 }


### PR DESCRIPTION
- Add KeycloakClientId property to Tre model
- Create IKeycloakAdminService interface and KeycloakAdminService implementation
- Store client credentials (clientId, clientSecret, clientUuid) in Vault
- Add KeycloakAdmin config section to appsettings for admin credentials
- Add EF Core migration for KeycloakClientId column
