### PR TITLE
feat: Submission API endpoint to get the child Submission info

### DIFF
--- a/Submission/Submission.Api/Controllers/SubmissionController.cs
+++ b/Submission/Submission.Api/Controllers/SubmissionController.cs
@@ -450,29 +450,38 @@ namespace Submission.Api.Controllers
         }
 
         [AllowAnonymous]
-        [HttpGet("GetChildSubmissionIdByParentAndTre")]
-        [SwaggerOperation("GetChildSubmissionIdByParentAndTre")]
-        [SwaggerResponse(statusCode: 200, type: typeof(int), description: "The ID of the child submission for the given ID of the parent Submission and TRE name")]
+        [HttpGet("GetChildSubmissionInfoByParentAndTre")]
+        [SwaggerOperation("GetChildSubmissionInfoByParentAndTre")]
+        [SwaggerResponse(statusCode: 200, type: typeof(int), description: "The ID and status of the child submission for the given ID of the parent Submission and TRE name")]
         [SwaggerResponse(statusCode: 404, description: "No matching child submission found")]
-        public async Task<IActionResult> GetChildSubmissionIdByParentAndTre(int parentSubmissionId, string treName)
+        public async Task<IActionResult> GetChildSubmissionInfoByParentAndTre(int parentSubmissionId, string treName)
         {
             try
             {
-                var childId = await _DbContext.Submissions
-                    .AsNoTracking()
-                    .Where(s => s.Parent != null && s.Parent.Id == parentSubmissionId && s.Tre != null && s.Tre.Name == treName)
-                    .Select(s => (int?)s.Id)
-                    .FirstOrDefaultAsync();
-
-                if (childId == null)
+              var child = await _DbContext.Submissions
+                .AsNoTracking()
+                .Where(s => s.Parent != null 
+                            && s.Parent.Id == parentSubmissionId 
+                            && s.Tre != null 
+                            && s.Tre.Name == treName)
+                .Select(s => new 
                 {
-                    Log.Warning("{Function} No child submission found for parentId={ParentId}, treName={TreName}",
-                        "GetChildSubmissionIdByParentAndTre", parentSubmissionId, treName);
-                    return NotFound();
-                }
+                  s.Id,
+                  s.Status
+                })
+                .FirstOrDefaultAsync();
 
-                Log.Information("{Function} Child submission found: {ChildId}", "GetChildSubmissionIdByParentAndTre", childId);
-                return Ok(childId);
+              if (child == null)
+              {
+                Log.Warning("{Function} No child submission found for parentId={ParentId}, treName={TreName}",
+                  "GetChildSubmissionIdByParentAndTre", parentSubmissionId, treName);
+                return NotFound();
+              }
+
+              Log.Information("{Function} Child submission found: {ChildId}", 
+                "GetChildSubmissionIdByParentAndTre", child.Id);
+
+              return Ok(child);
             }
             catch (Exception ex)
             {

--- a/Submission/Submission.Api/Controllers/SubmissionController.cs
+++ b/Submission/Submission.Api/Controllers/SubmissionController.cs
@@ -452,7 +452,7 @@ namespace Submission.Api.Controllers
         [AllowAnonymous]
         [HttpGet("GetChildSubmissionIdByParentAndTre")]
         [SwaggerOperation("GetChildSubmissionIdByParentAndTre")]
-        [SwaggerResponse(statusCode: 200, type: typeof(int), description: "The ID of the child submission for the given parent and TRE name")]
+        [SwaggerResponse(statusCode: 200, type: typeof(int), description: "The ID of the child submission for the given ID of the parent Submission and TRE name")]
         [SwaggerResponse(statusCode: 404, description: "No matching child submission found")]
         public async Task<IActionResult> GetChildSubmissionIdByParentAndTre(int parentSubmissionId, string treName)
         {

--- a/Submission/Submission.Api/Controllers/SubmissionController.cs
+++ b/Submission/Submission.Api/Controllers/SubmissionController.cs
@@ -449,6 +449,38 @@ namespace Submission.Api.Controllers
             }
         }
 
+        [AllowAnonymous]
+        [HttpGet("GetChildSubmissionIdByParentAndTre")]
+        [SwaggerOperation("GetChildSubmissionIdByParentAndTre")]
+        [SwaggerResponse(statusCode: 200, type: typeof(int), description: "The ID of the child submission for the given parent and TRE name")]
+        [SwaggerResponse(statusCode: 404, description: "No matching child submission found")]
+        public async Task<IActionResult> GetChildSubmissionIdByParentAndTre(int parentSubmissionId, string treName)
+        {
+            try
+            {
+                var childId = await _DbContext.Submissions
+                    .AsNoTracking()
+                    .Where(s => s.Parent != null && s.Parent.Id == parentSubmissionId && s.Tre != null && s.Tre.Name == treName)
+                    .Select(s => (int?)s.Id)
+                    .FirstOrDefaultAsync();
+
+                if (childId == null)
+                {
+                    Log.Warning("{Function} No child submission found for parentId={ParentId}, treName={TreName}",
+                        "GetChildSubmissionIdByParentAndTre", parentSubmissionId, treName);
+                    return NotFound();
+                }
+
+                Log.Information("{Function} Child submission found: {ChildId}", "GetChildSubmissionIdByParentAndTre", childId);
+                return Ok(childId);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "{Function} Crashed", "GetChildSubmissionIdByParentAndTre");
+                throw;
+            }
+        }
+
         [HttpGet("GetSubmissionsForCurrentUser")]
         public List<FiveSafesTes.Core.Models.Submission> GetSubmissionsForCurrentUser()
         {


### PR DESCRIPTION
### :hammer_and_wrench: Pull Request
<!-- # Delete content types that don't apply to your pull request -->
✨ Feature

#### Description:
This PR added a small API endpoint to the Submission layer API to get the children submission ID and status based on the parent Submission ID and the target TRE's name.

This will support the WorkBench library to get the correct children task IDs in a reliable way while fetching the Minio results.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :paperclip: Have commits been checked for accidental file inclusions?  
