### PR TITLE
feat: Get Keycloak config from discovery URL

### DIFF
--- a/Agent/Agent.Api/Controllers/ConfigurationController.cs
+++ b/Agent/Agent.Api/Controllers/ConfigurationController.cs
@@ -20,10 +20,4 @@ public class ConfigurationController : Controller
     {
         await _configurationService.AddConfigurationToVault(json, nameof(VaultConfigSettings));
     }
-
-    [HttpPost("ObserveConfig")]
-    public async Task ObserveConfig()
-    {
-        _configurationService.ObserveConfig();
-    }
 }

--- a/Agent/Agent.Api/Controllers/ConfigurationController.cs
+++ b/Agent/Agent.Api/Controllers/ConfigurationController.cs
@@ -1,4 +1,6 @@
+using Agent.Api.Models;
 using Agent.Api.Services;
+using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Agent.Api.Controllers;
@@ -17,7 +19,8 @@ public class ConfigurationController : Controller
     [HttpPost("AddConfigurationToVault/{json}")]
     public async Task AddConfigurationToVault(string json)
     {
-        await _configurationService.AddConfigurationToVault(json);
+        string decoded = Uri.UnescapeDataString(json); // TEMP - we'll use stringcontent when we're actually doing this
+        await _configurationService.AddConfigurationToVault(decoded, nameof(VaultConfigSettings));
     }
 
     [HttpPost("ObserveConfig")]

--- a/Agent/Agent.Api/Controllers/ConfigurationController.cs
+++ b/Agent/Agent.Api/Controllers/ConfigurationController.cs
@@ -1,6 +1,5 @@
 using Agent.Api.Models;
 using Agent.Api.Services;
-using Google.Protobuf.WellKnownTypes;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Agent.Api.Controllers;
@@ -16,11 +15,10 @@ public class ConfigurationController : Controller
         _configurationService = configService;
     }
 
-    [HttpPost("AddConfigurationToVault/{json}")]
-    public async Task AddConfigurationToVault(string json)
+    [HttpPost("AddConfigurationToVault")]
+    public async Task AddConfigurationToVault([FromBody] string json)
     {
-        string decoded = Uri.UnescapeDataString(json); // TEMP - we'll use stringcontent when we're actually doing this
-        await _configurationService.AddConfigurationToVault(decoded, nameof(VaultConfigSettings));
+        await _configurationService.AddConfigurationToVault(json, nameof(VaultConfigSettings));
     }
 
     [HttpPost("ObserveConfig")]

--- a/Agent/Agent.Api/Controllers/ConfigurationController.cs
+++ b/Agent/Agent.Api/Controllers/ConfigurationController.cs
@@ -19,4 +19,10 @@ public class ConfigurationController : Controller
     {
         await _configurationService.AddConfigurationToVault(json);
     }
+
+    [HttpPost("ObserveConfig")]
+    public async Task ObserveConfig()
+    {
+        _configurationService.ObserveConfig();
+    }
 }

--- a/Agent/Agent.Api/Controllers/OnboardingController.cs
+++ b/Agent/Agent.Api/Controllers/OnboardingController.cs
@@ -1,0 +1,23 @@
+
+using Agent.Api.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Agent.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class OnboardingController
+{
+    private readonly IOnboardingService _onboardingService;
+
+    public OnboardingController(IOnboardingService onboardingService)
+    {
+        _onboardingService = onboardingService;
+    }
+
+    [HttpPost("AddKeycloakSettingsToVault")]
+    public async Task AddKeycloakSettingsToVault()
+    {
+        await _onboardingService.AddKeycloakSettingsToVault();
+    }
+}

--- a/Agent/Agent.Api/Controllers/SubmissionCredentialsController.cs
+++ b/Agent/Agent.Api/Controllers/SubmissionCredentialsController.cs
@@ -1,4 +1,4 @@
-﻿using Agent.Api.Repositories.DbContexts;
+using Agent.Api.Repositories.DbContexts;
 using Agent.Api.Services;
 using FiveSafesTes.Core.Models;
 using FiveSafesTes.Core.Models.APISimpleTypeReturns;
@@ -6,6 +6,7 @@ using FiveSafesTes.Core.Models.Settings;
 using FiveSafesTes.Core.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Agent.Api.Controllers
 {
@@ -19,8 +20,10 @@ namespace Agent.Api.Controllers
         private readonly IEncDecHelper _encDecHelper;
         private readonly KeycloakTokenHelper _keycloakTokenHelper;
 
-        public SubmissionCredentialsController(ApplicationDbContext applicationDbContext, IEncDecHelper encDec, SubmissionKeyCloakSettings keycloakSettings)
+        public SubmissionCredentialsController(ApplicationDbContext applicationDbContext, IEncDecHelper encDec, IOptionsMonitor<SubmissionKeyCloakSettings> settings)
         {
+            SubmissionKeyCloakSettings keycloakSettings = settings.CurrentValue;
+
             _encDecHelper = encDec;
             _DbContext = applicationDbContext;
             _keycloakTokenHelper = new KeycloakTokenHelper(keycloakSettings.BaseUrl, keycloakSettings.ClientId,

--- a/Agent/Agent.Api/Models/VaultConfigDTO.cs
+++ b/Agent/Agent.Api/Models/VaultConfigDTO.cs
@@ -1,9 +1,0 @@
-using FiveSafesTes.Core.Models.Settings;
-
-namespace Agent.Api.Models;
-
-public class VaultConfigDTO
-{
-    public VaultConfigSettings VaultConfigSettings { get; set; }
-    public SubmissionKeyCloakSettings SubmissionKeyCloakSettings { get; set; }
-}

--- a/Agent/Agent.Api/Models/VaultConfigDTO.cs
+++ b/Agent/Agent.Api/Models/VaultConfigDTO.cs
@@ -1,0 +1,9 @@
+using FiveSafesTes.Core.Models.Settings;
+
+namespace Agent.Api.Models;
+
+public class VaultConfigDTO
+{
+    public VaultConfigSettings VaultConfigSettings { get; set; }
+    public SubmissionKeyCloakSettings SubmissionKeyCloakSettings { get; set; }
+}

--- a/Agent/Agent.Api/Program.cs
+++ b/Agent/Agent.Api/Program.cs
@@ -103,10 +103,12 @@ configuration.Bind(nameof(dataEgressKeyCloakSettings), dataEgressKeyCloakSetting
 dataEgressKeyCloakSettings.KeycloakDemoMode = keycloakDemomode;
 builder.Services.AddSingleton(dataEgressKeyCloakSettings);
 
-var submissionKeyCloakSettings = new SubmissionKeyCloakSettings();
+/*var submissionKeyCloakSettings = new SubmissionKeyCloakSettings();
 configuration.Bind(nameof(submissionKeyCloakSettings), submissionKeyCloakSettings);
 submissionKeyCloakSettings.KeycloakDemoMode = keycloakDemomode;
-builder.Services.AddSingleton(submissionKeyCloakSettings);
+builder.Services.AddSingleton(submissionKeyCloakSettings);*/
+
+builder.Services.Configure<SubmissionKeyCloakSettings>(configuration.GetSection("SubmissionKeyCloakSettings"));
 
 var HasuraSettings = new HasuraSettings();
 configuration.Bind(nameof(HasuraSettings), HasuraSettings);

--- a/Agent/Agent.Api/Program.cs
+++ b/Agent/Agent.Api/Program.cs
@@ -103,11 +103,6 @@ configuration.Bind(nameof(dataEgressKeyCloakSettings), dataEgressKeyCloakSetting
 dataEgressKeyCloakSettings.KeycloakDemoMode = keycloakDemomode;
 builder.Services.AddSingleton(dataEgressKeyCloakSettings);
 
-/*var submissionKeyCloakSettings = new SubmissionKeyCloakSettings();
-configuration.Bind(nameof(submissionKeyCloakSettings), submissionKeyCloakSettings);
-submissionKeyCloakSettings.KeycloakDemoMode = keycloakDemomode;
-builder.Services.AddSingleton(submissionKeyCloakSettings);*/
-
 builder.Services.Configure<SubmissionKeyCloakSettings>(configuration.GetSection("SubmissionKeyCloakSettings"));
 
 var HasuraSettings = new HasuraSettings();
@@ -171,6 +166,7 @@ builder.Services.AddScoped<IHasuraService, HasuraService>();
 builder.Services.AddScoped<IHasuraAuthenticationService, HasuraAuthenticationService>();
 builder.Services.AddScoped<IKeyCloakService, KeyCloakService>();
 builder.Services.AddScoped<IConfigurationService, ConfigurationService>();
+builder.Services.AddScoped<IOnboardingService, OnboardingService>();
 
 var TVP = new TokenValidationParameters
 {
@@ -299,6 +295,7 @@ using (var scope = app.Services.CreateScope())
     }
     credDb.Database.Migrate();
 
+    scope.ServiceProvider.GetRequiredService<IOptionsMonitor<SubmissionKeyCloakSettings>>().CurrentValue.KeycloakDemoMode = keycloakDemomode;
     var options = app.Services.GetRequiredService<IOptions<VaultSettings>>().Value;
     IAuthMethodInfo authMethod = new TokenAuthMethodInfo(options.Token);
     var vaultClientSettings = new VaultClientSettings(options.BaseUrl, authMethod);

--- a/Agent/Agent.Api/Services/ConfigurationService.cs
+++ b/Agent/Agent.Api/Services/ConfigurationService.cs
@@ -8,6 +8,7 @@ using Serilog;
 using VaultSharp;
 using VaultSharp.V1.AuthMethods;
 using VaultSharp.V1.AuthMethods.Token;
+using VaultSharp.V1.Commons;
 
 namespace Agent.Api.Services;
 
@@ -35,31 +36,36 @@ public class ConfigurationService : IConfigurationService
     /// Extract configuration values from a given json string and add or update the corresponding values in Vault.
     /// </summary>
     /// <param name="json">The json containing the configuration values we want to add to Vault.</param>
-    public async Task AddConfigurationToVault(string json)
+    /// <param name="prefix">The name of the model the given values should bind to when read by the vault configuration provider.</param>
+    public async Task AddConfigurationToVault(string json, string prefix)
     {
-        VaultConfigDTO? configDTO = DeserializeConfigJson(json);
+        Dictionary<string, object>? config = DeserializeConfigJson(json);
+        Dictionary<string, object> existingConfig;
 
-        if (configDTO != null)
+        if (config != null)
         {
-            Dictionary<string, object?> configValues = new();
-
-            // Add each value from the configuration settings
-            foreach (KeyValuePair<string, object?> kvp in AppendPrefixToSettingsValues(configDTO.VaultConfigSettings, nameof(VaultConfigSettings)))
+            try
             {
-                configValues[kvp.Key] = kvp.Value;
+                Secret<SecretData> vaultData = await _vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(_vaultSettings.VaultConfigPath, mountPoint: _vaultSettings.SecretEngine);
+                existingConfig = vaultData.Data.Data.ToDictionary();
+            }
+            catch (Exception)
+            {
+                // We don't have any secrets at this location yet.
+                existingConfig = [];
             }
 
-            // Add each value from the submission keycloak settings
-            foreach (KeyValuePair<string, object?> kvp in AppendPrefixToSettingsValues(configDTO.SubmissionKeyCloakSettings, nameof(SubmissionKeyCloakSettings)))
+            // As vault is versioned, we must merge our existing data with our new data manually.
+            Dictionary<string, object> mergedConfig = new(existingConfig);
+
+            foreach (var kvp in config)
             {
-                configValues[kvp.Key] = kvp.Value;
+                string key = $"{prefix}:{kvp.Key}";
+                mergedConfig[key] = kvp.Value;
             }
 
-            await _vaultClient.V1.Secrets.KeyValue.V2.WriteSecretAsync(
-                path: _vaultSettings.VaultConfigPath,
-                data: configValues,
-                mountPoint: _vaultSettings.SecretEngine
-            );
+            await _vaultClient.V1.Secrets.KeyValue.V2.WriteSecretAsync(_vaultSettings.VaultConfigPath, mergedConfig, mountPoint: _vaultSettings.SecretEngine);
+            
         }
         else
         {
@@ -72,38 +78,16 @@ public class ConfigurationService : IConfigurationService
     /// </summary>
     /// <param name="json">The json containing our configuration values.</param>
     /// <returns>A model representing our vault configuration, or null if the input json is invalid.</returns>
-    public VaultConfigDTO? DeserializeConfigJson(string json)
+    public Dictionary<string, object>? DeserializeConfigJson(string json)
     {
         try
         {
-            return JsonSerializer.Deserialize<VaultConfigDTO>(json);
+            return JsonSerializer.Deserialize<Dictionary<string, object>>(json);
         }
         catch (Exception)
         {
             return null;
         }
-    }
-
-    /// <summary>
-    /// Append the correct prefix to the start of each of our vault configuration values.
-    /// </summary>
-    /// <param name="settingsObj">The settings model containing the values we want to append the given prefix to.</param>
-    /// <param name="prefix">The prefix we are appending to the values. Should match that of the appsettings.</param>
-    /// <returns></returns>
-    public static Dictionary<string, object?> AppendPrefixToSettingsValues(object settingsObj, string prefix)
-    {
-        Dictionary<string, object?> values = new();
-
-        foreach (PropertyInfo property in settingsObj.GetType().GetProperties())
-        {
-            // Ignore properties with the JsonIgnore attribute.
-            if (Attribute.IsDefined(property, typeof(JsonIgnoreAttribute))) continue;
-
-            object? value = property.GetValue(settingsObj);
-            values[$"{prefix}:{property.Name}"] = value;
-        }
-
-        return values;
     }
 
     public void ObserveConfig()

--- a/Agent/Agent.Api/Services/ConfigurationService.cs
+++ b/Agent/Agent.Api/Services/ConfigurationService.cs
@@ -87,10 +87,4 @@ public class ConfigurationService : IConfigurationService
             return null;
         }
     }
-
-    public void ObserveConfig()
-    {
-        var x = _keycloakSettings;
-        var y = _configSettings;
-    }
 }

--- a/Agent/Agent.Api/Services/ConfigurationService.cs
+++ b/Agent/Agent.Api/Services/ConfigurationService.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using Agent.Api.Models;
 using FiveSafesTes.Core.Models.Settings;
 using Microsoft.Extensions.Options;
+using Serilog;
 using VaultSharp;
 using VaultSharp.V1.AuthMethods;
 using VaultSharp.V1.AuthMethods.Token;
@@ -12,7 +13,7 @@ namespace Agent.Api.Services;
 
 public class ConfigurationService : IConfigurationService
 {
-    private readonly IVaultClient _vaultClient;
+    private readonly VaultClient _vaultClient;
 
     public readonly VaultSettings _vaultSettings;
     // IOptionsMonitor used to retrieve latest values from vault at runtime.
@@ -27,7 +28,7 @@ public class ConfigurationService : IConfigurationService
 
         IAuthMethodInfo authMethod = new TokenAuthMethodInfo(_vaultSettings.Token);
         VaultClientSettings vaultClientSettings = new(_vaultSettings.BaseUrl, authMethod);
-        _vaultClient = new VaultClient(vaultClientSettings);
+        _vaultClient = new(vaultClientSettings);
     }
 
     /// <summary>
@@ -62,7 +63,7 @@ public class ConfigurationService : IConfigurationService
         }
         else
         {
-            // invalid json format
+            Log.Error("ConfigurationService:AddConfigurationToVault - Invalid JSON format");
         }
     }
 
@@ -95,7 +96,7 @@ public class ConfigurationService : IConfigurationService
 
         foreach (PropertyInfo property in settingsObj.GetType().GetProperties())
         {
-            // Ignore values with the JsonIgnore attribute.
+            // Ignore properties with the JsonIgnore attribute.
             if (Attribute.IsDefined(property, typeof(JsonIgnoreAttribute))) continue;
 
             object? value = property.GetValue(settingsObj);

--- a/Agent/Agent.Api/Services/ConfigurationService.cs
+++ b/Agent/Agent.Api/Services/ConfigurationService.cs
@@ -1,11 +1,12 @@
+using System.Reflection;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Agent.Api.Models;
 using FiveSafesTes.Core.Models.Settings;
 using Microsoft.Extensions.Options;
 using VaultSharp;
 using VaultSharp.V1.AuthMethods;
 using VaultSharp.V1.AuthMethods.Token;
-using static IdentityModel.ClaimComparer;
 
 namespace Agent.Api.Services;
 
@@ -16,11 +17,13 @@ public class ConfigurationService : IConfigurationService
     public readonly VaultSettings _vaultSettings;
     // IOptionsMonitor used to retrieve latest values from vault at runtime.
     public readonly IOptionsMonitor<VaultConfigSettings> _configSettings;  
+    public readonly IOptionsMonitor<SubmissionKeyCloakSettings> _keycloakSettings;  
 
-    public ConfigurationService(IOptions<VaultSettings> vaultSettings, IOptionsMonitor<VaultConfigSettings> configSettings)
+    public ConfigurationService(IOptions<VaultSettings> vaultSettings, IOptionsMonitor<VaultConfigSettings> configSettings, IOptionsMonitor<SubmissionKeyCloakSettings> keycloakSettings)
     {
         _vaultSettings = vaultSettings?.Value ?? throw new ArgumentNullException(nameof(vaultSettings));
         _configSettings = configSettings;
+        _keycloakSettings = keycloakSettings;
 
         IAuthMethodInfo authMethod = new TokenAuthMethodInfo(_vaultSettings.Token);
         VaultClientSettings vaultClientSettings = new(_vaultSettings.BaseUrl, authMethod);
@@ -33,13 +36,27 @@ public class ConfigurationService : IConfigurationService
     /// <param name="json">The json containing the configuration values we want to add to Vault.</param>
     public async Task AddConfigurationToVault(string json)
     {
-        Dictionary<string, object>? config = DeserializeConfigJsonToDictionary(json);
+        VaultConfigDTO? configDTO = DeserializeConfigJson(json);
 
-        if (config != null)
+        if (configDTO != null)
         {
+            Dictionary<string, object?> configValues = new();
+
+            // Add each value from the configuration settings
+            foreach (KeyValuePair<string, object?> kvp in AppendPrefixToSettingsValues(configDTO.VaultConfigSettings, nameof(VaultConfigSettings)))
+            {
+                configValues[kvp.Key] = kvp.Value;
+            }
+
+            // Add each value from the submission keycloak settings
+            foreach (KeyValuePair<string, object?> kvp in AppendPrefixToSettingsValues(configDTO.SubmissionKeyCloakSettings, nameof(SubmissionKeyCloakSettings)))
+            {
+                configValues[kvp.Key] = kvp.Value;
+            }
+
             await _vaultClient.V1.Secrets.KeyValue.V2.WriteSecretAsync(
                 path: _vaultSettings.VaultConfigPath,
-                data: config,
+                data: configValues,
                 mountPoint: _vaultSettings.SecretEngine
             );
         }
@@ -50,15 +67,15 @@ public class ConfigurationService : IConfigurationService
     }
 
     /// <summary>
-    /// Deserialize our json configuration into a dictionary. 
+    /// Deserialize our json configuration into the vault configuration model. 
     /// </summary>
     /// <param name="json">The json containing our configuration values.</param>
-    /// <returns>A dictionary containing the configuration, or null if the input json is invalid.</returns>
-    public Dictionary<string, object>? DeserializeConfigJsonToDictionary(string json)
+    /// <returns>A model representing our vault configuration, or null if the input json is invalid.</returns>
+    public VaultConfigDTO? DeserializeConfigJson(string json)
     {
         try
         {
-            return JsonSerializer.Deserialize<Dictionary<string, object>>(json);
+            return JsonSerializer.Deserialize<VaultConfigDTO>(json);
         }
         catch (Exception)
         {
@@ -67,19 +84,30 @@ public class ConfigurationService : IConfigurationService
     }
 
     /// <summary>
-    /// Deserialize our json configuration into the vault configuration model. 
+    /// Append the correct prefix to the start of each of our vault configuration values.
     /// </summary>
-    /// <param name="json">The json containing our configuration values.</param>
-    /// <returns>A model representing our vault configuration, or null if the input json is invalid.</returns>
-    public VaultConfigSettings? DeserializeConfigJson(string json)
+    /// <param name="settingsObj">The settings model containing the values we want to append the given prefix to.</param>
+    /// <param name="prefix">The prefix we are appending to the values. Should match that of the appsettings.</param>
+    /// <returns></returns>
+    public static Dictionary<string, object?> AppendPrefixToSettingsValues(object settingsObj, string prefix)
     {
-        try
+        Dictionary<string, object?> values = new();
+
+        foreach (PropertyInfo property in settingsObj.GetType().GetProperties())
         {
-            return JsonSerializer.Deserialize<VaultConfigSettings>(json);
+            // Ignore values with the JsonIgnore attribute.
+            if (Attribute.IsDefined(property, typeof(JsonIgnoreAttribute))) continue;
+
+            object? value = property.GetValue(settingsObj);
+            values[$"{prefix}:{property.Name}"] = value;
         }
-        catch (Exception)
-        {
-            return null;
-        }
+
+        return values;
+    }
+
+    public void ObserveConfig()
+    {
+        var x = _keycloakSettings;
+        var y = _configSettings;
     }
 }

--- a/Agent/Agent.Api/Services/ConfigurationService.cs
+++ b/Agent/Agent.Api/Services/ConfigurationService.cs
@@ -1,6 +1,4 @@
-using System.Reflection;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Agent.Api.Models;
 using FiveSafesTes.Core.Models.Settings;
 using Microsoft.Extensions.Options;

--- a/Agent/Agent.Api/Services/DareClientWithoutTokenHelper.cs
+++ b/Agent/Agent.Api/Services/DareClientWithoutTokenHelper.cs
@@ -1,7 +1,8 @@
-﻿using Agent.Api.Repositories.DbContexts;
+using Agent.Api.Repositories.DbContexts;
 using FiveSafesTes.Core.Models;
 using FiveSafesTes.Core.Models.Settings;
 using FiveSafesTes.Core.Services;
+using Microsoft.Extensions.Options;
 
 namespace Agent.Api.Services
 {
@@ -11,9 +12,11 @@ namespace Agent.Api.Services
 
         public DareClientWithoutTokenHelper(IHttpClientFactory httpClientFactory,
             IHttpContextAccessor httpContextAccessor, IConfiguration config, ApplicationDbContext db,
-            IEncDecHelper encDec, SubmissionKeyCloakSettings settings) : base(httpClientFactory, httpContextAccessor,
+            IEncDecHelper encDec, IOptionsMonitor<SubmissionKeyCloakSettings> keycloakSettings) : base(httpClientFactory, httpContextAccessor,
             config["DareAPISettings:Address"], false)
         {
+            SubmissionKeyCloakSettings settings = keycloakSettings.CurrentValue;
+
             CredDb = db;
             _keycloakTokenHelper = new KeycloakTokenHelper(settings.BaseUrl, settings.ClientId, settings.ClientSecret, settings.Proxy, settings.ProxyAddresURL, settings.KeycloakDemoMode);
 

--- a/Agent/Agent.Api/Services/IConfigurationService.cs
+++ b/Agent/Agent.Api/Services/IConfigurationService.cs
@@ -1,5 +1,3 @@
-using Agent.Api.Models;
-
 namespace Agent.Api.Services;
 
 public interface IConfigurationService

--- a/Agent/Agent.Api/Services/IConfigurationService.cs
+++ b/Agent/Agent.Api/Services/IConfigurationService.cs
@@ -4,5 +4,4 @@ public interface IConfigurationService
 {
     Dictionary<string, object>? DeserializeConfigJson(string json);
     Task AddConfigurationToVault(string json, string prefix);
-    void ObserveConfig();
 }

--- a/Agent/Agent.Api/Services/IConfigurationService.cs
+++ b/Agent/Agent.Api/Services/IConfigurationService.cs
@@ -4,7 +4,7 @@ namespace Agent.Api.Services;
 
 public interface IConfigurationService
 {
-    VaultConfigDTO? DeserializeConfigJson(string json);
-    Task AddConfigurationToVault(string json);
+    Dictionary<string, object>? DeserializeConfigJson(string json);
+    Task AddConfigurationToVault(string json, string prefix);
     void ObserveConfig();
 }

--- a/Agent/Agent.Api/Services/IConfigurationService.cs
+++ b/Agent/Agent.Api/Services/IConfigurationService.cs
@@ -4,7 +4,7 @@ namespace Agent.Api.Services;
 
 public interface IConfigurationService
 {
-    Dictionary<string, object>? DeserializeConfigJsonToDictionary(string json);
-    VaultConfigSettings? DeserializeConfigJson(string json);
+    VaultConfigDTO? DeserializeConfigJson(string json);
     Task AddConfigurationToVault(string json);
+    void ObserveConfig();
 }

--- a/Agent/Agent.Api/Services/IOnboardingService.cs
+++ b/Agent/Agent.Api/Services/IOnboardingService.cs
@@ -1,0 +1,6 @@
+namespace Agent.Api.Services;
+
+public interface IOnboardingService
+{
+    Task AddKeycloakSettingsToVault();
+}

--- a/Agent/Agent.Api/Services/OnboardingService.cs
+++ b/Agent/Agent.Api/Services/OnboardingService.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using Agent.Api.Models;
+using FiveSafesTes.Core.Models.Settings;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Serilog;
+
+namespace Agent.Api.Services;
+
+public class OnboardingService : IOnboardingService
+{
+    private readonly IOptionsMonitor<VaultConfigSettings> _vaultConfigSettings;
+    private readonly IConfigurationService _configurationService;
+
+    public OnboardingService(IConfigurationService configService, IOptionsMonitor<VaultConfigSettings> configSettings)
+    {
+        _configurationService = configService;
+        _vaultConfigSettings = configSettings;
+    }
+
+    public async Task AddKeycloakSettingsToVault()
+    {
+        if (!string.IsNullOrEmpty(_vaultConfigSettings.CurrentValue.SubmissionURL))
+        {
+            try
+            {
+                ConfigurationManager<OpenIdConnectConfiguration> configManager = new(_vaultConfigSettings.CurrentValue.SubmissionURL, new OpenIdConnectConfigurationRetriever());
+                OpenIdConnectConfiguration config = await configManager.GetConfigurationAsync();
+
+                var keycloakConfig = new
+                {
+                    Authority = config.Issuer,
+                    BaseUrl = config.Issuer
+                };
+
+                await _configurationService.AddConfigurationToVault(JsonSerializer.Serialize(keycloakConfig), nameof(SubmissionKeyCloakSettings));
+            }
+            catch (Exception ex)
+            {
+                Log.Error("OnboardingService:AddKeycloakSettingsToVault - " + ex.Message);
+            }
+        }
+        else
+        {
+            Log.Error("OnboardingService:AddKeycloakSettingsToVault - Submission URL is missing.");
+        }
+    }
+}

--- a/Agent/Agent.Api/Services/OnboardingService.cs
+++ b/Agent/Agent.Api/Services/OnboardingService.cs
@@ -24,11 +24,11 @@ public class OnboardingService : IOnboardingService
     /// </summary>
     public async Task AddKeycloakSettingsToVault()
     {
-        if (!string.IsNullOrEmpty(_vaultConfigSettings.CurrentValue.SubmissionURL))
+        if (!string.IsNullOrEmpty(_vaultConfigSettings.CurrentValue.KeycloakRealmSettingURL))
         {
             try
             {
-                ConfigurationManager<OpenIdConnectConfiguration> configManager = new(_vaultConfigSettings.CurrentValue.SubmissionURL, new OpenIdConnectConfigurationRetriever());
+                ConfigurationManager<OpenIdConnectConfiguration> configManager = new(_vaultConfigSettings.CurrentValue.KeycloakRealmSettingURL, new OpenIdConnectConfigurationRetriever());
                 OpenIdConnectConfiguration config = await configManager.GetConfigurationAsync();
 
                 var keycloakConfig = new
@@ -46,7 +46,7 @@ public class OnboardingService : IOnboardingService
         }
         else
         {
-            Log.Error("OnboardingService:AddKeycloakSettingsToVault - Submission URL is missing.");
+            Log.Error("OnboardingService:AddKeycloakSettingsToVault - Realm Config URL is missing.");
         }
     }
 }

--- a/Agent/Agent.Api/Services/OnboardingService.cs
+++ b/Agent/Agent.Api/Services/OnboardingService.cs
@@ -19,6 +19,9 @@ public class OnboardingService : IOnboardingService
         _vaultConfigSettings = configSettings;
     }
 
+    /// <summary>
+    /// Retrieve the submission layer OpenID configuration and add the appropriate values to Vault.
+    /// </summary>
     public async Task AddKeycloakSettingsToVault()
     {
         if (!string.IsNullOrEmpty(_vaultConfigSettings.CurrentValue.SubmissionURL))

--- a/Agent/Agent.Api/VaultConfigurationProvider.cs
+++ b/Agent/Agent.Api/VaultConfigurationProvider.cs
@@ -1,3 +1,4 @@
+using Serilog;
 using VaultSharp;
 using VaultSharp.V1.Commons;
 
@@ -24,16 +25,23 @@ public class VaultConfigurationProvider: ConfigurationProvider, IDisposable
 
     private async Task LoadAsync()
     {
-        Secret<SecretData> secret = await _vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(_path, mountPoint: _mountPoint);
-        IDictionary<string, object> data = secret.Data.Data;
-
-        Dictionary<string, string?> newData = data.ToDictionary(k => $"{nameof(Models.VaultConfigSettings)}:{k.Key}", v => v.Value?.ToString());
-
-        // Do not reload if there are no changes to the values in vault.
-        if (!Data.SequenceEqual(newData))
+        try
         {
-            Data = newData;
-            OnReload();
+            Secret<SecretData> secret = await _vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(_path, mountPoint: _mountPoint);
+            IDictionary<string, object> data = secret.Data.Data;
+
+            Dictionary<string, string?> newData = data.ToDictionary(k => k.Key, v => v.Value?.ToString());
+
+            // Do not reload if there are no changes to the values in vault.
+            if (!Data.SequenceEqual(newData))
+            {
+                Data = newData;
+                OnReload();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error("VaultConfigurationProvider:LoadAsync - " + ex.Message);
         }
     }
 

--- a/Shared/FiveSafesTes.Core/Models/Settings/BaseKeyCloakSettings.cs
+++ b/Shared/FiveSafesTes.Core/Models/Settings/BaseKeyCloakSettings.cs
@@ -1,6 +1,7 @@
-﻿using System.Runtime;
+using System.Runtime;
 using System.Net;
 using Serilog;
+using System.Text.Json.Serialization;
 
 namespace FiveSafesTes.Core.Models.Settings
 {
@@ -39,6 +40,7 @@ namespace FiveSafesTes.Core.Models.Settings
         
         public bool RequireHttpsMetadata { get; set; }
 
+        [JsonIgnore]
         public HttpClientHandler getProxyHandler {
             get
             {

--- a/Shared/FiveSafesTes.Core/Models/Settings/BaseKeyCloakSettings.cs
+++ b/Shared/FiveSafesTes.Core/Models/Settings/BaseKeyCloakSettings.cs
@@ -1,7 +1,6 @@
 using System.Runtime;
 using System.Net;
 using Serilog;
-using System.Text.Json.Serialization;
 
 namespace FiveSafesTes.Core.Models.Settings
 {
@@ -40,7 +39,6 @@ namespace FiveSafesTes.Core.Models.Settings
         
         public bool RequireHttpsMetadata { get; set; }
 
-        [JsonIgnore]
         public HttpClientHandler getProxyHandler {
             get
             {


### PR DESCRIPTION
### :hammer_and_wrench: Pull Request
<!-- # Delete content types that don't apply to your pull request -->
✨ Feature
#### Description:
- Created OnboardingController and OnboardingService to house onboarding-related functions.
- Added method to retrieve open id configuration from the keycloak discovery URL and add those values to vault.
- Keycloak values in vault are prioritised over those in appsettings.
- Agent.API SubmissionKeycloakSettings is no longer a singleton so updates to the configuration can apply while the program is running.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :paperclip: Have commits been checked for accidental file inclusions?  
