### PR TITLE
feat: add onboarding API to retrieve credentials

### DIFF
--- a/Shared/FiveSafesTes.Core/Models/UsedOnboardingJti.cs
+++ b/Shared/FiveSafesTes.Core/Models/UsedOnboardingJti.cs
@@ -1,0 +1,14 @@
+namespace FiveSafesTes.Core.Models
+{
+    /// <summary>
+    /// Tracks onboarding JWT identifiers (jti claim) that have already been
+    /// redeemed via the Onboarding API to enforce one-time use.
+    /// </summary>
+    public class UsedOnboardingJti
+    {
+        public int Id { get; set; }
+        public string Jti { get; set; } = string.Empty;
+        public int TreId { get; set; }
+        public DateTime UsedAt { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Shared/FiveSafesTes.Core/Models/ViewModels/OnboardingCredentialsResponse.cs
+++ b/Shared/FiveSafesTes.Core/Models/ViewModels/OnboardingCredentialsResponse.cs
@@ -1,0 +1,15 @@
+namespace FiveSafesTes.Core.Models.ViewModels
+{
+    /// <summary>
+    /// Response returned by the Submission Onboarding API when an Agent successfully
+    /// exchanges its temporary onboarding JWT for its long-term Keycloak service account
+    /// credentials retrieved from Vault.
+    /// </summary>
+    public class OnboardingCredentialsResponse
+    {
+        public int TreId { get; set; }
+        public string TreName { get; set; } = string.Empty;
+        public string ClientId { get; set; } = string.Empty;
+        public string ClientSecret { get; set; } = string.Empty;
+    }
+}

--- a/Submission/Submission.Api/Controllers/OnboardingController.cs
+++ b/Submission/Submission.Api/Controllers/OnboardingController.cs
@@ -1,0 +1,111 @@
+using FiveSafesTes.Core.Models;
+using FiveSafesTes.Core.Models.ViewModels;
+using FiveSafesTes.Core.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+using Submission.Api.Repositories.DbContexts;
+
+namespace Submission.Api.Controllers
+{
+    [ApiExplorerSettings(GroupName = "v1")]
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class OnboardingController : Controller
+    {
+        private readonly ApplicationDbContext _dbContext;
+        private readonly IVaultCredentialsService _vaultCredentialsService;
+
+        public OnboardingController(
+            ApplicationDbContext dbContext,
+            IVaultCredentialsService vaultCredentialsService)
+        {
+            _dbContext = dbContext;
+            _vaultCredentialsService = vaultCredentialsService;
+        }
+
+        [HttpPost("RetrieveCredentials")]
+        public async Task<IActionResult> RetrieveCredentials()
+        {
+            try
+            {
+                // Service-account tokens normally expose client identity in azp.
+                var clientId = User.FindFirst("azp")?.Value ?? User.FindFirst("client_id")?.Value;
+                if (string.IsNullOrWhiteSpace(clientId))
+                {
+                    return Unauthorized(new { error = "Token does not contain a service account client id claim" });
+                }
+
+                // jti is a unique token id; we persist it to prevent it from being used again.
+                var jti = User.FindFirst("jti")?.Value;
+                if (string.IsNullOrWhiteSpace(jti))
+                {
+                    return Unauthorized(new { error = "Token does not contain jti claim" });
+                }
+
+                var alreadyUsed = await _dbContext.UsedOnboardingJtis.AnyAsync(x => x.Jti == jti);
+                if (alreadyUsed)
+                {
+                    Log.Warning("{Function} Replay attempt for jti {Jti}", "RetrieveCredentials", jti);
+                    return Unauthorized(new { error = "Token has already been used" });
+                }
+
+                // Client id maps to the TRE's provisioned Keycloak service account.
+                var tre = await _dbContext.Tres.FirstOrDefaultAsync(x => x.KeycloakClientId == clientId);
+                if (tre == null)
+                {
+                    Log.Warning("{Function} TRE for clientId {ClientId} was not found", "RetrieveCredentials", clientId);
+                    return NotFound(new { error = "TRE not found for provided service account" });
+                }
+
+                var vaultPath = $"tre/{tre.Name.ToLowerInvariant()}/keycloak";
+                Dictionary<string, object> creds;
+                try
+                {
+                    creds = await _vaultCredentialsService.GetCredentialAsync(vaultPath);
+                }
+                catch (Exception vaultEx)
+                {
+                    Log.Error(vaultEx, "{Function} Failed to read credentials from Vault for TRE {TreName}",
+                        "RetrieveCredentials", tre.Name);
+                    return StatusCode(500, new { error = "Could not retrieve credentials" });
+                }
+
+                if (creds == null
+                    || !creds.TryGetValue("clientId", out var clientIdObj)
+                    || !creds.TryGetValue("clientSecret", out var clientSecretObj))
+                {
+                    Log.Error("{Function} Vault did not contain expected credentials for TRE {TreName}",
+                        "RetrieveCredentials", tre.Name);
+                    return StatusCode(500, new { error = "Credentials are not provisioned for this TRE" });
+                }
+
+                _dbContext.UsedOnboardingJtis.Add(new UsedOnboardingJti
+                {
+                    Jti = jti,
+                    TreId = tre.Id,
+                    UsedAt = DateTime.UtcNow
+                });
+                await _dbContext.SaveChangesAsync();
+
+                Log.Information("{Function} Onboarding credentials issued for TRE {TreName} (clientId={ClientId}, jti={Jti})",
+                    "RetrieveCredentials", tre.Name, clientId, jti);
+
+                return Ok(new OnboardingCredentialsResponse
+                {
+                    TreId = tre.Id,
+                    TreName = tre.Name,
+                    ClientId = clientIdObj?.ToString() ?? string.Empty,
+                    ClientSecret = clientSecretObj?.ToString() ?? string.Empty
+                });
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "{Function} Crashed", "RetrieveCredentials");
+                return StatusCode(500, new { error = "An internal server error occurred" });
+            }
+        }
+    }
+}

--- a/Submission/Submission.Api/Migrations/20260430195836_AddUsedOnboardingJtis.Designer.cs
+++ b/Submission/Submission.Api/Migrations/20260430195836_AddUsedOnboardingJtis.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Submission.Api.Repositories.DbContexts;
@@ -11,9 +12,11 @@ using Submission.Api.Repositories.DbContexts;
 namespace Submission.Api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260430195836_AddUsedOnboardingJtis")]
+    partial class AddUsedOnboardingJtis
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Submission/Submission.Api/Migrations/20260430195836_AddUsedOnboardingJtis.cs
+++ b/Submission/Submission.Api/Migrations/20260430195836_AddUsedOnboardingJtis.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Submission.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUsedOnboardingJtis : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UsedOnboardingJtis",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Jti = table.Column<string>(type: "text", nullable: false),
+                    TreId = table.Column<int>(type: "integer", nullable: false),
+                    UsedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UsedOnboardingJtis", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UsedOnboardingJtis_Jti",
+                table: "UsedOnboardingJtis",
+                column: "Jti",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UsedOnboardingJtis");
+        }
+    }
+}

--- a/Submission/Submission.Api/Repositories/DbContexts/ApplicationDbContext.cs
+++ b/Submission/Submission.Api/Repositories/DbContexts/ApplicationDbContext.cs
@@ -1,4 +1,4 @@
-﻿using FiveSafesTes.Core.Models;
+using FiveSafesTes.Core.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace Submission.Api.Repositories.DbContexts
@@ -31,8 +31,15 @@ namespace Submission.Api.Repositories.DbContexts
 
         public DbSet<MembershipTreDecision> MembershipTreDecisions { get; set; }
 
+        public DbSet<UsedOnboardingJti> UsedOnboardingJtis { get; set; }
 
-
-
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+            modelBuilder.Entity<UsedOnboardingJti>(b =>
+            {
+                b.HasIndex(x => x.Jti).IsUnique();
+            });
+        }
     }
 }


### PR DESCRIPTION
-  add `POST /api/Onboarding/RetrieveCredentials` to exchange a Keycloak-issued service-account token for TRE credentials stored in Vault.
- Implement TREFX-589

### :hammer_and_wrench: Pull Request
<!-- # Delete content types that don't apply to your pull request -->
♻️ Refactor
✨ Feature
🦋 Bug Fix
⚡️ Optimization
📝 Documentation
🛠️ Repo maintenance
#### Description:
A clear and concise description of what you are changing.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :paperclip: Have commits been checked for accidental file inclusions?  
