### PR TITLE
feat: Show additional feedback on submission credentials UI

### DIFF
--- a/Agent/Agent.Api/Controllers/OnboardingController.cs
+++ b/Agent/Agent.Api/Controllers/OnboardingController.cs
@@ -55,4 +55,18 @@ public class OnboardingController : Controller
         _onboardingService.RestartHangfireJobs();
         return new() { Result = true };
     }
+
+    [HttpGet("IsTreSynced")]
+    public async Task<BoolReturn> IsTreSynced()
+    {
+        bool result = _onboardingService.IsTRESynced();
+        return new() { Result = result };
+    }
+
+    [HttpGet("IsConfigurationUploaded")]
+    public async Task<BoolReturn> IsConfigurationUploaded()
+    {
+        bool result = _onboardingService.IsConfigurationUploaded();
+        return new() { Result = result };
+    }
 }

--- a/Agent/Agent.Api/Controllers/OnboardingController.cs
+++ b/Agent/Agent.Api/Controllers/OnboardingController.cs
@@ -45,7 +45,9 @@ public class OnboardingController : Controller
         return new()
         {
             Success = true,
-            Message = "File uploaded successfully."
+            Message = "File uploaded successfully.",
+            IsUploaded = true,
+            IsSynced = _onboardingService.IsTRESynced()
         };
     }
 

--- a/Agent/Agent.Api/Controllers/SubmissionCredentialsController.cs
+++ b/Agent/Agent.Api/Controllers/SubmissionCredentialsController.cs
@@ -5,6 +5,7 @@ using FiveSafesTes.Core.Models;
 using FiveSafesTes.Core.Models.APISimpleTypeReturns;
 using FiveSafesTes.Core.Models.Enums;
 using FiveSafesTes.Core.Models.Settings;
+using FiveSafesTes.Core.Models.ViewModels;
 using FiveSafesTes.Core.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -82,7 +83,10 @@ namespace Agent.Api.Controllers
                 ConfigInputMethod = ConfigInputMethod.Manual
             };
 
+            object uploadDataToSave = new { IsConfigurationImported = true };
+
             await _configurationService.AddConfigurationToVault(JsonSerializer.Serialize(credsToSave), nameof(SubmissionKeyCloakSettings));
+            await _configurationService.AddConfigurationToVault(JsonSerializer.Serialize(uploadDataToSave), nameof(TreOnboardingConfig));
 
             // Reload config to apply updated credentials immediately.
             await _vaultConfigProvider.LoadAsync(bypassConfigCheck: true);

--- a/Agent/Agent.Api/Controllers/SubmissionCredentialsController.cs
+++ b/Agent/Agent.Api/Controllers/SubmissionCredentialsController.cs
@@ -89,7 +89,7 @@ namespace Agent.Api.Controllers
             await _configurationService.AddConfigurationToVault(JsonSerializer.Serialize(uploadDataToSave), nameof(TreOnboardingConfig));
 
             // Reload config to apply updated credentials immediately.
-            await _vaultConfigProvider.LoadAsync(bypassConfigCheck: true);
+            await _vaultConfigProvider.LoadAsync();
 
             return creds;
         }
@@ -100,7 +100,7 @@ namespace Agent.Api.Controllers
         {
             // Wipe any previously uploaded keycloak settings from vault.
             await _configurationService.RemoveConfigurationFromVault(nameof(SubmissionKeyCloakSettings));
-            await _vaultConfigProvider.LoadAsync(bypassConfigCheck: true);
+            await _vaultConfigProvider.LoadAsync();
             return new() { Result = true };
         }
     }

--- a/Agent/Agent.Api/Controllers/SubmissionCredentialsController.cs
+++ b/Agent/Agent.Api/Controllers/SubmissionCredentialsController.cs
@@ -93,5 +93,15 @@ namespace Agent.Api.Controllers
 
             return creds;
         }
+
+        [Authorize(Roles = "dare-tre-admin")]
+        [HttpPost("WipeVaultCredentials")]
+        public async Task<BoolReturn> WipeVaultCredentials()
+        {
+            // Wipe any previously uploaded keycloak settings from vault.
+            await _configurationService.RemoveConfigurationFromVault(nameof(SubmissionKeyCloakSettings));
+            await _vaultConfigProvider.LoadAsync(bypassConfigCheck: true);
+            return new() { Result = true };
+        }
     }
 }

--- a/Agent/Agent.Api/Controllers/SubmissionCredentialsController.cs
+++ b/Agent/Agent.Api/Controllers/SubmissionCredentialsController.cs
@@ -24,8 +24,9 @@ namespace Agent.Api.Controllers
         private readonly IConfigurationService _configurationService;
         private readonly VaultConfigurationProvider _vaultConfigProvider;
         private readonly SubmissionKeyCloakSettings _keycloakSettings;
+        private readonly IDareClientWithoutTokenHelper _clientHelper;
 
-        public SubmissionCredentialsController(IConfiguration config, IEncDecHelper encDec, IOptionsMonitor<SubmissionKeyCloakSettings> settings, IConfigurationService configurationService)
+        public SubmissionCredentialsController(IConfiguration config, IEncDecHelper encDec, IOptionsMonitor<SubmissionKeyCloakSettings> settings, IConfigurationService configurationService, IDareClientWithoutTokenHelper clientHelper)
         {
             _keycloakSettings = settings.CurrentValue;
 
@@ -34,6 +35,7 @@ namespace Agent.Api.Controllers
                 _keycloakSettings.ClientSecret, _keycloakSettings.Proxy, _keycloakSettings.ProxyAddresURL, _keycloakSettings.KeycloakDemoMode);
             _configurationService = configurationService;
             _vaultConfigProvider = ((IConfigurationRoot)config).Providers.OfType<VaultConfigurationProvider>().FirstOrDefault();
+            _clientHelper = clientHelper;
         }
 
         [Authorize(Roles = "dare-tre-admin")]
@@ -76,6 +78,8 @@ namespace Agent.Api.Controllers
                 return creds;
             }
 
+            creds.Valid = true;
+
             object credsToSave = new
             {
                 Username = creds.UserName,
@@ -100,8 +104,22 @@ namespace Agent.Api.Controllers
         {
             // Wipe any previously uploaded keycloak settings from vault.
             await _configurationService.RemoveConfigurationFromVault(nameof(SubmissionKeyCloakSettings));
+
+            // We no longer have any config so set imported to false.
+            object uploadDataToSave = new { IsConfigurationImported = false };
+            await _configurationService.AddConfigurationToVault(JsonSerializer.Serialize(uploadDataToSave), nameof(TreOnboardingConfig));
+
+            // Reload config to reflect changes.
             await _vaultConfigProvider.LoadAsync();
             return new() { Result = true };
+        }
+
+
+        [Authorize(Roles = "dare-tre-admin")]
+        [HttpGet("IsUserAssignedTRE")]
+        public async Task<BoolReturn> IsUserAssignedTRE()
+        {
+            return await _clientHelper.CallAPIWithoutModel<BoolReturn>("/api/Tre/IsUserAssignedTRE");
         }
     }
 }

--- a/Agent/Agent.Api/Services/ConfigurationService.cs
+++ b/Agent/Agent.Api/Services/ConfigurationService.cs
@@ -72,6 +72,11 @@ public class ConfigurationService : IConfigurationService
         }
     }
 
+    public async Task RemoveConfigurationFromVault(string json, string prefix)
+    {
+
+    }
+
     /// <summary>
     /// Deserialize our json configuration into the vault configuration model. 
     /// </summary>

--- a/Agent/Agent.Api/Services/ConfigurationService.cs
+++ b/Agent/Agent.Api/Services/ConfigurationService.cs
@@ -72,6 +72,10 @@ public class ConfigurationService : IConfigurationService
         }
     }
 
+    /// <summary>
+    /// Removes all configuration values from vault for a given model.
+    /// </summary>
+    /// <param name="prefix">The name of the model containing the values we want to remove.</param>
     public async Task RemoveConfigurationFromVault(string prefix)
     {
         Dictionary<string, object> existingConfig;

--- a/Agent/Agent.Api/Services/ConfigurationService.cs
+++ b/Agent/Agent.Api/Services/ConfigurationService.cs
@@ -72,9 +72,37 @@ public class ConfigurationService : IConfigurationService
         }
     }
 
-    public async Task RemoveConfigurationFromVault(string json, string prefix)
+    public async Task RemoveConfigurationFromVault(string prefix)
     {
+        Dictionary<string, object> existingConfig;
 
+        try
+        {
+            Secret<SecretData> vaultData = await _vaultClient.V1.Secrets.KeyValue.V2.ReadSecretAsync(_vaultSettings.VaultConfigPath, mountPoint: _vaultSettings.SecretEngine);
+            existingConfig = vaultData.Data.Data.ToDictionary();
+        }
+        catch (Exception)
+        {
+            // We don't have any secrets at this location yet.
+            existingConfig = [];
+        }
+
+        // We should only keep the configuration with keys that do not start with the given prefix.
+        Dictionary<string, object> updatedConfig = new();
+
+        foreach (KeyValuePair<string, object> kvp in existingConfig)
+        {
+            if (!kvp.Key.StartsWith($"{prefix}:"))
+            {
+                updatedConfig[kvp.Key] = kvp.Value;
+            }
+            else
+            {
+                continue;
+            }
+        }
+
+        await _vaultClient.V1.Secrets.KeyValue.V2.WriteSecretAsync(_vaultSettings.VaultConfigPath, updatedConfig, mountPoint: _vaultSettings.SecretEngine);
     }
 
     /// <summary>

--- a/Agent/Agent.Api/Services/IConfigurationService.cs
+++ b/Agent/Agent.Api/Services/IConfigurationService.cs
@@ -4,5 +4,5 @@ public interface IConfigurationService
 {
     Dictionary<string, object>? DeserializeConfigJson(string json);
     Task AddConfigurationToVault(string json, string prefix);
-    Task RemoveConfigurationFromVault(string json, string prefix);
+    Task RemoveConfigurationFromVault(string prefix);
 }

--- a/Agent/Agent.Api/Services/IConfigurationService.cs
+++ b/Agent/Agent.Api/Services/IConfigurationService.cs
@@ -4,4 +4,5 @@ public interface IConfigurationService
 {
     Dictionary<string, object>? DeserializeConfigJson(string json);
     Task AddConfigurationToVault(string json, string prefix);
+    Task RemoveConfigurationFromVault(string json, string prefix);
 }

--- a/Agent/Agent.Api/Services/IOnboardingService.cs
+++ b/Agent/Agent.Api/Services/IOnboardingService.cs
@@ -4,4 +4,7 @@ public interface IOnboardingService
 {
     Task UploadJsonConfig(IFormFile file);
     void RestartHangfireJobs();
+    bool IsTRESynced();
+    bool IsConfigurationUploaded();
+    void ClearVaultKeycloakDetails();
 }

--- a/Agent/Agent.Api/Services/IOnboardingService.cs
+++ b/Agent/Agent.Api/Services/IOnboardingService.cs
@@ -6,5 +6,4 @@ public interface IOnboardingService
     void RestartHangfireJobs();
     bool IsTRESynced();
     bool IsConfigurationUploaded();
-    void ClearVaultKeycloakDetails();
 }

--- a/Agent/Agent.Api/Services/OnboardingService.cs
+++ b/Agent/Agent.Api/Services/OnboardingService.cs
@@ -1,7 +1,5 @@
 using System.Net.Http.Headers;
 using System.Text.Json;
-using Agent.Api.Repositories.DbContexts;
-using FiveSafesTes.Core.Models;
 using FiveSafesTes.Core.Models.Enums;
 using FiveSafesTes.Core.Models.Settings;
 using FiveSafesTes.Core.Models.ViewModels;
@@ -24,6 +22,8 @@ public class OnboardingService : IOnboardingService
     private readonly JobSettings _jobSettings;
     private readonly VaultConfigurationProvider _vaultConfigProvider;
 
+    private readonly string submissionAddress;
+
     public OnboardingService(IConfiguration config, IConfigurationService configService, IOptionsMonitor<TreOnboardingConfig> configSettings, 
         JobSettings jobSettings, IEncDecHelper encDec, IServiceProvider serviceProvider)
     {
@@ -34,6 +34,7 @@ public class OnboardingService : IOnboardingService
         _vaultConfigProvider = ((IConfigurationRoot)config).Providers.OfType<VaultConfigurationProvider>().FirstOrDefault();
         _encDecHelper = encDec;
         _serviceProvider = serviceProvider;
+        submissionAddress = config["DareAPISettings:Address"];
     }
 
     /// <summary>
@@ -47,15 +48,15 @@ public class OnboardingService : IOnboardingService
 
         await _configurationService.AddConfigurationToVault(json, nameof(TreOnboardingConfig));
 
-        // Update configuration immediately - we must bypass the check to see if config has been uploaded or the method will stop too soon.
-        await _vaultConfigProvider.LoadAsync(bypassConfigCheck: true);
+        // Update configuration immediately
+        await _vaultConfigProvider.LoadAsync();
 
         await AddKeycloakSettingsToVault(_onboardingConfig.CurrentValue.KeycloakRealmSettingURL);
 
         await LogIntoSubmissionLayer();
 
         // Update configuration again to apply new vault changes
-        await _vaultConfigProvider.LoadAsync(bypassConfigCheck: true);
+        await _vaultConfigProvider.LoadAsync();
 
         SyncWithSubmission();
         RestartHangfireJobs();
@@ -166,6 +167,9 @@ public class OnboardingService : IOnboardingService
         }
     }
 
+    /// <summary>
+    /// Sync the submission layer with the TRE.
+    /// </summary>
     public void SyncWithSubmission()
     {
         using (var scope = _serviceProvider.CreateScope())
@@ -175,13 +179,23 @@ public class OnboardingService : IOnboardingService
         }
     }
 
+    /// <summary>
+    /// Determines whether we have uploaded our configuration.
+    /// </summary>
+    /// <returns>Returns true if config has been uploaded.</returns>
     public bool IsConfigurationUploaded()
     {
         return _onboardingConfig.CurrentValue.IsConfigurationImported;
     }
 
+    /// <summary>
+    /// Determines whether we are able to sync with the submission layer.
+    /// </summary>
+    /// <returns>Returns true if we are able to reach the submission layer.</returns>
     public bool IsTRESynced()
     {
-        return true;
+        using HttpClient client = new();
+        HttpResponseMessage response = client.GetAsync(submissionAddress + "/v1/get_test_tes").Result;
+        return response.IsSuccessStatusCode;
     }
 }

--- a/Agent/Agent.Api/Services/OnboardingService.cs
+++ b/Agent/Agent.Api/Services/OnboardingService.cs
@@ -174,4 +174,19 @@ public class OnboardingService : IOnboardingService
             var result = dareSyncHelper.SyncSubmissionWithTre().Result;
         }
     }
+
+    public bool IsConfigurationUploaded()
+    {
+        return _onboardingConfig.CurrentValue.IsConfigurationImported;
+    }
+
+    public bool IsTRESynced()
+    {
+        return true;
+    }
+
+    public void ClearVaultKeycloakDetails()
+    {
+        _configurationService.RemoveConfigurationFromVault("", nameof(SubmissionKeyCloakSettings));
+    }
 }

--- a/Agent/Agent.Api/Services/OnboardingService.cs
+++ b/Agent/Agent.Api/Services/OnboardingService.cs
@@ -184,9 +184,4 @@ public class OnboardingService : IOnboardingService
     {
         return true;
     }
-
-    public void ClearVaultKeycloakDetails()
-    {
-        _configurationService.RemoveConfigurationFromVault("", nameof(SubmissionKeyCloakSettings));
-    }
 }

--- a/Agent/Agent.Api/Services/OnboardingService.cs
+++ b/Agent/Agent.Api/Services/OnboardingService.cs
@@ -194,8 +194,21 @@ public class OnboardingService : IOnboardingService
     /// <returns>Returns true if we are able to reach the submission layer.</returns>
     public bool IsTRESynced()
     {
-        using HttpClient client = new();
-        HttpResponseMessage response = client.GetAsync(submissionAddress + "/v1/get_test_tes").Result;
-        return response.IsSuccessStatusCode;
+        if (string.IsNullOrEmpty(submissionAddress))
+        {
+            return false;
+        }
+
+        try
+        {
+            using HttpClient client = new();
+            HttpResponseMessage response = client.GetAsync(submissionAddress + "/v1/get_test_tes").Result;
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "{Function} Could not reach Submission at {Url}", "IsTRESynced", submissionAddress);
+            return false;
+        }
     }
 }

--- a/Agent/Agent.Api/VaultConfigurationProvider.cs
+++ b/Agent/Agent.Api/VaultConfigurationProvider.cs
@@ -23,18 +23,18 @@ public class VaultConfigurationProvider: ConfigurationProvider, IDisposable
 
         Load();
 
-        // Check vault for changes in values at the given interval.
-        _timer = new Timer(async _ => await LoadAsync(), null, reloadInterval, reloadInterval);
+        // Check vault for changes in values at the given interval, but only once config is uploaded.
+        _timer = new Timer(async _ => await LoadAsync(requireImportedConfig: true), null, reloadInterval, reloadInterval);
     }
 
     /// <summary>
     /// Reload the configuration to apply any changes to values in Vault.
     /// </summary>
-    /// <param name="bypassConfigCheck">When true, allows the loading to proceed irrespective of whether config has been uploaded to Vault.</param>
-    public async Task LoadAsync(bool bypassConfigCheck = false)
+    /// <param name="requireImportedConfig">When false, allows the loading to proceed irrespective of whether config has been uploaded to Vault.</param>
+    public async Task LoadAsync(bool requireImportedConfig = false)
     {
-        // Onboarding configuration can never be true until config is reloaded, so we need a way of bypassing this check when we're uploading the config.
-        if (!_onboardingConfig.CurrentValue.IsConfigurationImported && !bypassConfigCheck)
+        // If we require config to be present for this load and it is absent, stop early.
+        if (!_onboardingConfig.CurrentValue.IsConfigurationImported && requireImportedConfig)
         {
             // Don't try to read configuration values from vault before the config has been uploaded.
             Log.Warning("VaultConfigurationProvider:LoadAsync - Configuration not yet set");

--- a/Agent/Agent.Web/Controllers/SubmissionConfigController.cs
+++ b/Agent/Agent.Web/Controllers/SubmissionConfigController.cs
@@ -1,3 +1,4 @@
+using Agent.Web.Services;
 using FiveSafesTes.Core.Models.APISimpleTypeReturns;
 using FiveSafesTes.Core.Models.ViewModels;
 using FiveSafesTes.Core.Services;
@@ -16,8 +17,10 @@ public class SubmissionConfigController : Controller
         _clientHelper = client;
     }
 
-    public IActionResult Index(JsonConfigUploadResponse response)
+    public async Task<IActionResult> Index(JsonConfigUploadResponse response)
     {
+        response.IsUploaded = await ControllerHelpers.IsConfigurationUploaded(_clientHelper);
+        response.IsSynced = await ControllerHelpers.IsTRESynced(_clientHelper);
         return View(response);
     }
 

--- a/Agent/Agent.Web/Controllers/SubmissionCredentialsController.cs
+++ b/Agent/Agent.Web/Controllers/SubmissionCredentialsController.cs
@@ -43,6 +43,10 @@ namespace Agent.Web.Controllers
                 return View(credentials);
             }
 
+            // First we need to make sure we remove any existing submission credentials to avoid conflicting information.
+            await ControllerHelpers.WipeVaultCredentials(_clientHelper);
+
+            // Then we can update the credentials.
             credentials.Creds = await ControllerHelpers.UpdateCredentials("SubmissionCredentials", _clientHelper, ModelState, credentials.Creds);
             credentials.IsConfigurationUploaded = await ControllerHelpers.IsConfigurationUploaded(_clientHelper);
             credentials.IsSynced = await ControllerHelpers.IsTRESynced(_clientHelper);

--- a/Agent/Agent.Web/Controllers/SubmissionCredentialsController.cs
+++ b/Agent/Agent.Web/Controllers/SubmissionCredentialsController.cs
@@ -1,4 +1,4 @@
-﻿using Agent.Web.Services;
+using Agent.Web.Services;
 using FiveSafesTes.Core.Models;
 using FiveSafesTes.Core.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -21,21 +21,33 @@ namespace Agent.Web.Controllers
 
         public async Task<IActionResult> UpdateCredentialsAsync()
         {
-            return View(await ControllerHelpers.CheckCredentialsAreValid("SubmissionCredentials", _clientHelper));
+            KeycloakCredentials creds = await ControllerHelpers.CheckCredentialsAreValid("SubmissionCredentials", _clientHelper);
+            bool configUploaded = await ControllerHelpers.IsConfigurationUploaded(_clientHelper);
+            bool treSynced = await ControllerHelpers.IsTRESynced(_clientHelper);
+
+            return View(new SubmissionKeycloakCredentialDTO() 
+            { 
+                Creds = creds,
+                IsSynced = treSynced,
+                IsConfigurationUploaded = configUploaded
+            });
             
         }
 
         [HttpPost]
         
-        public async Task<IActionResult> UpdateCredentials(KeycloakCredentials credentials) {
+        public async Task<IActionResult> UpdateCredentials(SubmissionKeycloakCredentialDTO credentials) {
 
             if (!ModelState.IsValid) // SonarQube security
             {
                 return View(credentials);
             }
-            credentials = await ControllerHelpers.UpdateCredentials("SubmissionCredentials", _clientHelper, ModelState,
-                    credentials);
-            if (credentials.Valid)
+
+            credentials.Creds = await ControllerHelpers.UpdateCredentials("SubmissionCredentials", _clientHelper, ModelState, credentials.Creds);
+            credentials.IsConfigurationUploaded = await ControllerHelpers.IsConfigurationUploaded(_clientHelper);
+            credentials.IsSynced = await ControllerHelpers.IsTRESynced(_clientHelper);
+
+            if (credentials.Creds.Valid)
             {
                 return RedirectToAction("Index", "Home");
             }

--- a/Agent/Agent.Web/Controllers/SubmissionCredentialsController.cs
+++ b/Agent/Agent.Web/Controllers/SubmissionCredentialsController.cs
@@ -48,18 +48,29 @@ namespace Agent.Web.Controllers
 
             // Then we can update the credentials.
             credentials.Creds = await ControllerHelpers.UpdateCredentials("SubmissionCredentials", _clientHelper, ModelState, credentials.Creds);
-            credentials.IsConfigurationUploaded = await ControllerHelpers.IsConfigurationUploaded(_clientHelper);
-            credentials.IsSynced = await ControllerHelpers.IsTRESynced(_clientHelper);
 
-            if (credentials.Creds.Valid)
+            // Ensure that the details are valid
+            if (credentials.Creds.Error || !credentials.Creds.Valid)
             {
-                return RedirectToAction("Index", "Home");
+                // Don't keep invalid credentials
+                await ControllerHelpers.WipeVaultCredentials(_clientHelper);
             }
             else
             {
-                return View(credentials);
+                credentials.IsConfigurationUploaded = await ControllerHelpers.IsConfigurationUploaded(_clientHelper);
+                credentials.IsSynced = await ControllerHelpers.IsTRESynced(_clientHelper);
+
+                // Ensure that the details belong to a user with a TRE
+                if (credentials.IsSynced && await ControllerHelpers.IsUserAssignedTRE(_clientHelper) == false)
+                {
+                    credentials.Creds.Valid = false;
+                    credentials.Creds.ErrorMessage = "User " + credentials.Creds.UserName + " doesn't have a TRE";
+                    // Don't keep invalid credentials
+                    await ControllerHelpers.WipeVaultCredentials(_clientHelper);
+                }
             }
-            
+
+            return View(credentials);
         }
 
     }

--- a/Agent/Agent.Web/Services/ControllerHelpers.cs
+++ b/Agent/Agent.Web/Services/ControllerHelpers.cs
@@ -45,5 +45,10 @@ namespace Agent.Web.Services
             BoolReturn result = await clientHelper.CallAPIWithoutModel<BoolReturn>("/api/Onboarding/IsConfigurationUploaded");
             return result.Result;
         }
+
+        public static async Task WipeVaultCredentials(ITREClientHelper clientHelper)
+        {
+            await clientHelper.CallAPIWithoutModel<BoolReturn>("/api/SubmissionCredentials/WipeVaultCredentials", httpMethod: HttpMethod.Post);
+        }
     }
 }

--- a/Agent/Agent.Web/Services/ControllerHelpers.cs
+++ b/Agent/Agent.Web/Services/ControllerHelpers.cs
@@ -50,5 +50,11 @@ namespace Agent.Web.Services
         {
             await clientHelper.CallAPIWithoutModel<BoolReturn>("/api/SubmissionCredentials/WipeVaultCredentials", httpMethod: HttpMethod.Post);
         }
+
+        public static async Task<bool> IsUserAssignedTRE(ITREClientHelper clientHelper)
+        {
+            BoolReturn result = await clientHelper.CallAPIWithoutModel<BoolReturn>("/api/SubmissionCredentials/IsUserAssignedTRE");
+            return result.Result;
+        }
     }
 }

--- a/Agent/Agent.Web/Services/ControllerHelpers.cs
+++ b/Agent/Agent.Web/Services/ControllerHelpers.cs
@@ -1,6 +1,8 @@
-﻿using FiveSafesTes.Core.Models;
+using System.Net;
+using FiveSafesTes.Core.Models;
 using FiveSafesTes.Core.Models.APISimpleTypeReturns;
 using FiveSafesTes.Core.Services;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Agent.Web.Services
@@ -30,6 +32,18 @@ namespace Agent.Web.Services
                 credentials.Valid = false;
                 return credentials;
             }
+        }
+
+        public static async Task<bool> IsTRESynced(ITREClientHelper clientHelper)
+        {
+            BoolReturn result = await clientHelper.CallAPIWithoutModel<BoolReturn>("/api/Onboarding/IsTRESynced");
+            return result.Result;
+        }
+
+        public static async Task<bool> IsConfigurationUploaded(ITREClientHelper clientHelper)
+        {
+            BoolReturn result = await clientHelper.CallAPIWithoutModel<BoolReturn>("/api/Onboarding/IsConfigurationUploaded");
+            return result.Result;
         }
     }
 }

--- a/Agent/Agent.Web/Views/SubmissionConfig/Index.cshtml
+++ b/Agent/Agent.Web/Views/SubmissionConfig/Index.cshtml
@@ -20,6 +20,28 @@
     </div>
     <div class="card shadow-sm">
         <div class="card-body">
+            @if (Model.IsSynced && Model.IsUploaded)
+            {
+                <span class="badge  px-2 badge-sm bg-success text-light rounded-pill m-0 ms-3">
+                    <i class="fa-solid fa-check-circle me-1"></i> Configuration uploaded and synced
+                </span>
+            }
+            else if (Model.IsUploaded)
+            {
+                <span class="badge  px-2 badge-sm bg-grey text-dark rounded-pill m-0 ms-3">
+                    <i class="fa-solid fa-ban me-1"></i> Configuration uploaded but not yet synced
+                </span>
+            }
+            else
+            {
+                <span class="badge  px-2 badge-sm bg-grey text-dark rounded-pill m-0 ms-3">
+                    <i class="fa-solid fa-ban me-1"></i> No configuration has been uploaded
+                </span>
+            }
+        </div>
+    </div>
+    <div class="card shadow-sm">
+        <div class="card-body">
 
             @{
                 if (Model != null && !string.IsNullOrEmpty(Model.Message))

--- a/Agent/Agent.Web/Views/SubmissionCredentials/UpdateCredentials.cshtml
+++ b/Agent/Agent.Web/Views/SubmissionCredentials/UpdateCredentials.cshtml
@@ -7,7 +7,7 @@
     <hr class="d-flex my-4">
     <div class="card shadow-sm">
         <div class="card-body">
-            @if (Model.IsSynced)
+            @if (Model.IsSynced && Model.IsConfigurationUploaded && Model.Creds.Valid)
             {
                 <span class="badge  px-2 badge-sm bg-success text-light rounded-pill m-0 ms-3">
                     <i class="fa-solid fa-check-circle me-1"></i> Online
@@ -23,30 +23,23 @@
     </div>
     </<br/>
     <div class="row">
-        @if (Model.IsConfigurationUploaded)
+        @if (Model.IsConfigurationUploaded && Model.Creds.Valid)
         {
             <div class="alert alert-info">
                 Your submission credentials have already been configured!
             </div>
         }
-        else
+        else if (!Model.Creds.Valid)
         {
-            <div class="d-flex align-items-center justify-content-between mb-4">
-                <div>
-                    @if (Model.Creds.Valid == false)
-                    {
-                        <div class="alert alert-warning">
-                            Submission Credentials are missing or invalid. Please update
-                        </div>
-                        @if (!string.IsNullOrEmpty(Model.Creds.ErrorMessage))
-                        {
-                            <div class="alert alert-danger">
-                                @Model.Creds.ErrorMessage
-                            </div>
-                        }
-                    }
-                </div>
+            <div class="alert alert-warning">
+                Submission Credentials are missing or invalid. Please update
             </div>
+            @if (!string.IsNullOrEmpty(Model.Creds.ErrorMessage))
+            {
+                <div class="alert alert-danger">
+                    @Model.Creds.ErrorMessage
+                </div>
+            }
         }
     </div>
     <div class="row">

--- a/Agent/Agent.Web/Views/SubmissionCredentials/UpdateCredentials.cshtml
+++ b/Agent/Agent.Web/Views/SubmissionCredentials/UpdateCredentials.cshtml
@@ -7,7 +7,7 @@
     <hr class="d-flex my-4">
     <div class="card shadow-sm">
         <div class="card-body">
-            @if (Model.IsSynced && Model.IsConfigurationUploaded && Model.Creds.Valid)
+            @if (Model.IsSynced && Model.IsConfigurationUploaded)
             {
                 <span class="badge  px-2 badge-sm bg-success text-light rounded-pill m-0 ms-3">
                     <i class="fa-solid fa-check-circle me-1"></i> Online
@@ -23,7 +23,7 @@
     </div>
     </<br/>
     <div class="row">
-        @if (Model.IsConfigurationUploaded && Model.Creds.Valid)
+        @if (Model.IsConfigurationUploaded)
         {
             <div class="alert alert-info">
                 Your submission credentials have already been configured!

--- a/Agent/Agent.Web/Views/SubmissionCredentials/UpdateCredentials.cshtml
+++ b/Agent/Agent.Web/Views/SubmissionCredentials/UpdateCredentials.cshtml
@@ -72,9 +72,18 @@
                     @Html.PasswordFor(x => x.Creds.ConfirmPassword, new { @class = "form-control show-tick noBottomMargin" })
                     @Html.ValidationMessageFor(m => m.Creds.ConfirmPassword)
                 </div>
-                <div class="mt-4">
-                    <button  type="submit" class="btn btn-sm btn-primary">Save Credentials</button>
-                </div>
+                @if (!Model.IsConfigurationUploaded)
+                {
+                    <div class="mt-4">
+                        <button  type="submit" class="btn btn-sm btn-primary">Save Credentials</button>
+                    </div>
+                }
+                else
+                {
+                    <button type="submit" class="btn btn-sm btn-primary" onclick="return confirm('Are you sure you want to save? Existing credentials will be overwritten.');">
+                        Save Credentials
+                    </button>
+                }
             }
         </div>
     </div> 

--- a/Agent/Agent.Web/Views/SubmissionCredentials/UpdateCredentials.cshtml
+++ b/Agent/Agent.Web/Views/SubmissionCredentials/UpdateCredentials.cshtml
@@ -1,41 +1,76 @@
-﻿@model FiveSafesTes.Core.Models.KeycloakCredentials
+@model FiveSafesTes.Core.Models.SubmissionKeycloakCredentialDTO
 @{
     ViewData["Title"] = "Submission Credentials";
 }
 <div class="container-lg p-4">
     <h1 class="fs-3 mb-0">Submission Credentials</h1>
     <hr class="d-flex my-4">
-    <div class="d-flex align-items-center justify-content-between mb-4">
-        <div>
-            @if (Model.Valid == false)
+    <div class="card shadow-sm">
+        <div class="card-body">
+            @if (Model.IsSynced)
             {
-                <h2 class="fs-5">Submission Credentials are missing or invalid. Please update</h2>
-                <h2 style="color:red" class="fs-5">@Model.ErrorMessage</h2>
+                <span class="badge  px-2 badge-sm bg-success text-light rounded-pill m-0 ms-3">
+                    <i class="fa-solid fa-check-circle me-1"></i> Online
+                </span>
+            }
+            else
+            {
+                <span class="badge  px-2 badge-sm bg-grey text-dark rounded-pill m-0 ms-3">
+                    <i class="fa-solid fa-ban me-1"></i> Offline
+                </span>
             }
         </div>
-    </div>  
+    </div>
+    </<br/>
+    <div class="row">
+        @if (Model.IsConfigurationUploaded)
+        {
+            <div class="alert alert-info">
+                Your submission credentials have already been configured!
+            </div>
+        }
+        else
+        {
+            <div class="d-flex align-items-center justify-content-between mb-4">
+                <div>
+                    @if (Model.Creds.Valid == false)
+                    {
+                        <div class="alert alert-warning">
+                            Submission Credentials are missing or invalid. Please update
+                        </div>
+                        @if (!string.IsNullOrEmpty(Model.Creds.ErrorMessage))
+                        {
+                            <div class="alert alert-danger">
+                                @Model.Creds.ErrorMessage
+                            </div>
+                        }
+                    }
+                </div>
+            </div>
+        }
+    </div>
     <div class="row">
         <div class="col-md-4">
             @using (Html.BeginForm("UpdateCredentials", "SubmissionCredentials", FormMethod.Post, new { id = "frmMain" }))
             {
                 @Html.AntiForgeryToken()
 
-                @Html.HiddenFor(m => m.Id)
+                @Html.HiddenFor(m => m.Creds.Id)
             
                 <div class="form-group">
-                    @Html.LabelFor(m => m.UserName, new { @class = "form-label"})
-                    @Html.TextBoxFor(x => x.UserName, new {@class = "form-control show-tick"})
-                    @Html.ValidationMessageFor(m => m.UserName)
+                    @Html.LabelFor(m => m.Creds.UserName, new { @class = "form-label"})
+                    @Html.TextBoxFor(x => x.Creds.UserName, new { @class = "form-control show-tick" })
+                    @Html.ValidationMessageFor(m => m.Creds.UserName)
                 </div>
                 <div class="form-group">
-                    @Html.LabelFor(m => m.PasswordEnc, new { @class = "form-label"})
-                    @Html.PasswordFor(x => x.PasswordEnc, new {@class = "form-control show-tick noBottomMargin"})
-                    @Html.ValidationMessageFor(m => m.PasswordEnc)
+                    @Html.LabelFor(m => m.Creds.PasswordEnc, new { @class = "form-label" })
+                    @Html.PasswordFor(x => x.Creds.PasswordEnc, new { @class = "form-control show-tick noBottomMargin" })
+                    @Html.ValidationMessageFor(m => m.Creds.PasswordEnc)
                 </div>
                 <div class="form-group">
-                    @Html.LabelFor(m => m.ConfirmPassword, new { @class = "form-label"})
-                    @Html.PasswordFor(x => x.ConfirmPassword, new {@class = "form-control show-tick noBottomMargin"})
-                    @Html.ValidationMessageFor(m => m.ConfirmPassword)
+                    @Html.LabelFor(m => m.Creds.ConfirmPassword, new { @class = "form-label" })
+                    @Html.PasswordFor(x => x.Creds.ConfirmPassword, new { @class = "form-control show-tick noBottomMargin" })
+                    @Html.ValidationMessageFor(m => m.Creds.ConfirmPassword)
                 </div>
                 <div class="mt-4">
                     <button  type="submit" class="btn btn-sm btn-primary">Save Credentials</button>

--- a/Agent/Agent.Web/appsettings.Development.json
+++ b/Agent/Agent.Web/appsettings.Development.json
@@ -33,7 +33,7 @@
 
 
   },
-  "sslcookies": "false",
+  "sslcookies": "true",
   "httpsRedirect": "false",
 
   "Serilog": {

--- a/Shared/FiveSafesTes.Core/Models/KeycloakCredentials.cs
+++ b/Shared/FiveSafesTes.Core/Models/KeycloakCredentials.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -34,5 +34,10 @@ namespace FiveSafesTes.Core.Models
         Egress = 2
     }
 
-    
+    public class SubmissionKeycloakCredentialDTO
+    {
+        public KeycloakCredentials Creds { get; set; }
+        public bool IsConfigurationUploaded { get; set; }
+        public bool IsSynced { get; set; }
+    }
 }

--- a/Shared/FiveSafesTes.Core/Models/ViewModels/JsonConfigUploadResponse.cs
+++ b/Shared/FiveSafesTes.Core/Models/ViewModels/JsonConfigUploadResponse.cs
@@ -4,4 +4,6 @@ public class JsonConfigUploadResponse
 {
     public bool Success { get; set; }
     public string Message { get; set; }
+    public bool IsSynced { get; set; }
+    public bool IsUploaded { get; set; }
 }

--- a/Submission/Submission.Api/Controllers/TreController.cs
+++ b/Submission/Submission.Api/Controllers/TreController.cs
@@ -12,6 +12,7 @@ using Submission.Api.Services;
 using Submission.Api.Services.Contract;
 using FiveSafesTes.Core.Services;
 using System.Text;
+using FiveSafesTes.Core.Models.APISimpleTypeReturns;
 
 namespace Submission.Api.Controllers
 {
@@ -360,6 +361,13 @@ namespace Submission.Api.Controllers
                 : _keycloakSettings.Realm;
 
             return $"{keycloakFullUrl}/realms/{realm}/.well-known/openid-configuration";
+        }
+
+        [Authorize(Roles = "dare-tre-admin")]
+        [HttpGet("IsUserAssignedTRE")]
+        public async Task<BoolReturn> IsUserAssignedTRE()
+        {
+            return new BoolReturn() { Result = ControllerHelpers.IsUserAssignedTRE(User, _DbContext) };
         }
     }
 }

--- a/Submission/Submission.Api/Services/ControllerHelpers.cs
+++ b/Submission/Submission.Api/Services/ControllerHelpers.cs
@@ -42,6 +42,21 @@ namespace Submission.Api.Services
             return tre;
         }
 
+        /// <summary>
+        /// Determine whether a user has a TRE without throwing an exception.
+        /// </summary>
+        public static bool IsUserAssignedTRE(ClaimsPrincipal loggedInUser, ApplicationDbContext dbContext)
+        {
+            try
+            {
+                Tre? tre = GetUserTre(loggedInUser, dbContext);
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
 
         public static async Task RemoveUserFromMinioBucket(User user, Project project,
             IHttpContextAccessor httpContextAccessor, string attributeName,

--- a/Submission/Submission.Web/appsettings.Development.json
+++ b/Submission/Submission.Web/appsettings.Development.json
@@ -49,7 +49,7 @@
       }
     }
   },
-  "sslcookies": "false",
+  "sslcookies": "true",
   "httpsRedirect": "false",
   "DareAPISettings": {
     "Address": "https://localhost:7163",


### PR DESCRIPTION
### :hammer_and_wrench: Pull Request
<!-- # Delete content types that don't apply to your pull request -->
✨ Feature
#### Description:
- The submission credentials UI now features messages that tell you whether configuration has already been uploaded and whether the TRE has synced.
- When manually inputting submission credentials, any existing credential values in vault are wiped to ensure that there is no conflicting information left over from, for example, a previous JSON config upload.
- Manual credential upload no longer accepts keycloak details if that user does not have a TRE and shows an error accordingly.
- Show configuration upload status icon on submission configuration UI to show your file upload was successful.
- Fixed an issue with VaultConfigProvider that prevented it from reading vault on startup.
## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :paperclip: Have commits been checked for accidental file inclusions?  
