### PR TITLE
feat: Remove Health Check Logs After 30 Days

### DIFF
--- a/Agent/Agent.Api/DoHealthCheckWork.cs
+++ b/Agent/Agent.Api/DoHealthCheckWork.cs
@@ -7,6 +7,7 @@ using FiveSafesTes.Core.Services;
 using Hangfire;
 using Microsoft.Extensions.Options;
 using FiveSafesTes.Core.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace Agent.Api;
 
@@ -42,6 +43,8 @@ public class DoHealthCheckWork : IDoHealthCheckWork
 
     public async Task Execute()
     {
+        await DeleteOldLogs();
+
         DoSyncHealthCheck();
         DoAgentHealthCheck();
         await DoEgressHealthCheck();
@@ -205,5 +208,16 @@ public class DoHealthCheckWork : IDoHealthCheckWork
         };
 
         _dbContext.HealthCheckStatus.Add(healthStatus);
+    }
+
+    /// <summary>
+    /// Logs that are more than 30 days old are removed from the database.
+    /// </summary>
+    private async Task DeleteOldLogs()
+    {
+        DateTime cutoffDate = DateTime.UtcNow.AddDays(-30);
+
+        await _dbContext.HealthCheckStatus.Where(x => x.DateTime < cutoffDate).ExecuteDeleteAsync();
+
     }
 }

--- a/Agent/Agent.Api/DoHealthCheckWork.cs
+++ b/Agent/Agent.Api/DoHealthCheckWork.cs
@@ -215,7 +215,7 @@ public class DoHealthCheckWork : IDoHealthCheckWork
     /// </summary>
     private async Task DeleteOldLogs()
     {
-        DateTime cutoffDate = DateTime.UtcNow.AddDays(-30);
+        DateTime cutoffDate = DateTime.UtcNow.AddDays(-_jobSettings.DaysBeforeHealthLogDeletion);
 
         await _dbContext.HealthCheckStatus.Where(x => x.DateTime < cutoffDate).ExecuteDeleteAsync();
 

--- a/Agent/Agent.Api/JobSettings.cs
+++ b/Agent/Agent.Api/JobSettings.cs
@@ -10,5 +10,6 @@ namespace Agent.Api
         public string SyncJobName { get; set; }
         public string ScanJobName { get; set; }
         public string HealthCheckJobName { get; set; }
+        public int DaysBeforeHealthLogDeletion { get; set; } = 30;
     }
 }

--- a/Agent/Agent.Api/appsettings.json
+++ b/Agent/Agent.Api/appsettings.json
@@ -12,7 +12,8 @@
     "healthCheckSchedule": 1,
     "SyncJobName": "Sync Projects and Membership",
     "ScanJobName": "Sync Submissions",
-    "HealthCheckJobName": "Health Check"
+    "HealthCheckJobName": "Health Check",
+    "DaysBeforeHealthLogDeletion":  30
   },
   "KeycloakDemoMode": "false",
   "DemoModeDefaultP": "",


### PR DESCRIPTION
### :hammer_and_wrench: Pull Request
<!-- # Delete content types that don't apply to your pull request -->
✨ Feature
#### Description:
Whenever the health check runs, existing health check logs are removed if they've been in the database for longer than 30 days to avoid accumulating too many rows.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :paperclip: Have commits been checked for accidental file inclusions?  
