### PR TITLE
refactor(api): use MetadataAddress for TRE onboarding Keycloak URL

### DIFF
--- a/Submission/Submission.Api/Controllers/TreController.cs
+++ b/Submission/Submission.Api/Controllers/TreController.cs
@@ -343,7 +343,7 @@ namespace Submission.Api.Controllers
                     TREId = tre.Id,
                     TREName = tre.Name,
                     SubmissionURL = _configuration["SubmissionApiUrl"] ?? string.Empty,
-                    KeycloakRealmSettingURL = GetOnboardingKeycloakMetadataUrl(),
+                    KeycloakRealmSettingURL = _keycloakSettings.MetadataAddress,
                     JWT = serviceAccountJwt,
                     IsConfigurationImported = true
                 };
@@ -362,19 +362,6 @@ namespace Submission.Api.Controllers
                 Log.Error(ex, "{Function} Crashed", "DownloadConfig");
                 return StatusCode(500, "An internal server error occurred");
             }
-        }
-
-        /// <summary>
-        /// Public OIDC discovery URL for TRE onboarding JSON, built from KeycloakFullURL.
-        /// </summary>
-        private string GetOnboardingKeycloakMetadataUrl()
-        {
-            var keycloakFullUrl = _configuration["KeycloakFullURL"]?.Trim().TrimEnd('/');
-            var realm = string.IsNullOrWhiteSpace(_keycloakSettings.Realm)
-                ? "Dare-Control"
-                : _keycloakSettings.Realm;
-
-            return $"{keycloakFullUrl}/realms/{realm}/.well-known/openid-configuration";
         }
 
         [Authorize(Roles = "dare-tre-admin")]

--- a/Submission/Submission.Api/appsettings.json
+++ b/Submission/Submission.Api/appsettings.json
@@ -92,7 +92,6 @@
     "ServiceAccountRole": "dare-tre-admin"
   },
   "SubmissionApiUrl": "",
-  "KeycloakFullURL": "http://localhost:8085",
   "Features": {
     "SeedDemoData": false
   }


### PR DESCRIPTION
TRE onboarding JSON now reads KeycloakRealmSettingURL from the same MetadataAddress used for API auth (SUBMISSION_KEYCLOAK_URL), removing the redundant KeycloakFullURL config.

### :hammer_and_wrench: Pull Request
<!-- # Delete content types that don't apply to your pull request -->
♻️ Refactor
✨ Feature
🦋 Bug Fix
⚡️ Optimization
📝 Documentation
🛠️ Repo maintenance
#### Description:
A clear and concise description of what you are changing.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :paperclip: Have commits been checked for accidental file inclusions?  
