### PR TITLE
fix: build URLs safely via a shared UrlHelper

### DIFF
--- a/Agent/Agent.Api/DoHealthCheckWork.cs
+++ b/Agent/Agent.Api/DoHealthCheckWork.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Agent.Api.Helpers;
 using Agent.Api.Models;
 using Agent.Api.Repositories.DbContexts;
 using FiveSafesTes.Core.Models.Enums;
@@ -57,7 +58,7 @@ public class DoHealthCheckWork(
       {
         using HttpClient client = new();
         HttpResponseMessage response =
-          await client.GetAsync(_apiEndpoints.SubmissionApiUrl + "/api/HealthCheck/CheckHealth");
+          await client.GetAsync(UrlHelper.Combine(_apiEndpoints.SubmissionApiUrl, "api/HealthCheck/CheckHealth"));
 
         if (!response.IsSuccessStatusCode)
         {

--- a/Agent/Agent.Api/Helpers/UrlHelper.cs
+++ b/Agent/Agent.Api/Helpers/UrlHelper.cs
@@ -1,0 +1,17 @@
+namespace Agent.Api.Helpers;
+
+public static class UrlHelper
+{
+    /// <summary>
+    /// Combines a base address and relative path into a URI, avoiding double-slash issues
+    /// when the base address already ends with a trailing slash.
+    /// </summary>
+    public static Uri Combine(string baseAddress, string relativePath)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(baseAddress);
+        ArgumentNullException.ThrowIfNull(relativePath);
+
+        var baseUri = new Uri(baseAddress.TrimEnd('/') + "/");
+        return new Uri(baseUri, relativePath.TrimStart('/'));
+    }
+}

--- a/Agent/Agent.Api/Services/HasuraService.cs
+++ b/Agent/Agent.Api/Services/HasuraService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net.Http.Headers;
 using System.Text;
+using Agent.Api.Helpers;
 using Agent.Api.Models;
 using Agent.Api.Repositories;
 using Agent.Api.Repositories.DbContexts;
@@ -73,7 +74,7 @@ namespace Agent.Api.Services
         public async Task SetUpDb(string DbName, string EnvironmentVariable)
         {
             // Set the endpoint URL
-            string endpointUrl = _hasuraSettings.HasuraURL + "/v1/metadata";
+            string endpointUrl = UrlHelper.Combine(_hasuraSettings.HasuraURL, "v1/metadata").ToString();
             /*
             // Create the JSON payload
             string payload = @"
@@ -170,7 +171,7 @@ namespace Agent.Api.Services
         {
 
             // Set the endpoint URL
-            string endpointUrl = _hasuraSettings.HasuraURL + "/v2/query";
+            string endpointUrl = UrlHelper.Combine(_hasuraSettings.HasuraURL, "v2/query").ToString();
 
             // Create the JSON payload
             string payload = @"
@@ -206,7 +207,7 @@ namespace Agent.Api.Services
         {
 
             // Set the endpoint URL
-            string endpointUrl = _hasuraSettings.HasuraURL + "/v2/query";
+            string endpointUrl = UrlHelper.Combine(_hasuraSettings.HasuraURL, "v2/query").ToString();
 
             // Create the JSON payload
             string payload = @"
@@ -243,7 +244,7 @@ namespace Agent.Api.Services
         public async Task<bool> TrackData(string Db, string Schema, string table)
         {
             // Set the endpoint URL
-            string endpointUrl = _hasuraSettings.HasuraURL + "/v1/metadata";
+            string endpointUrl = UrlHelper.Combine(_hasuraSettings.HasuraURL, "v1/metadata").ToString();
             /*
             // Create the JSON payload
             string payload = @"
@@ -339,7 +340,7 @@ namespace Agent.Api.Services
         public async Task SetPermission(string Db, string Schema, string table)
         {
             // Set the endpoint URL
-            string endpointUrl = _hasuraSettings.HasuraURL + "/v1/metadata";
+            string endpointUrl = UrlHelper.Combine(_hasuraSettings.HasuraURL, "v1/metadata").ToString();
 
             // Create the JSON payload
             string payload = @"
@@ -387,7 +388,7 @@ namespace Agent.Api.Services
           
 
             //need to get the headers to send from the token userid
-            string endpointUrl = _hasuraSettings.HasuraURL + "/v1/graphql";
+            string endpointUrl = UrlHelper.Combine(_hasuraSettings.HasuraURL, "v1/graphql").ToString();
             try
             {
                 var Result = await HttpClient(endpointUrl, Query, false, Token);

--- a/Agent/Agent.Api/Services/OnboardingService.cs
+++ b/Agent/Agent.Api/Services/OnboardingService.cs
@@ -4,6 +4,7 @@ using FiveSafesTes.Core.Models.Enums;
 using FiveSafesTes.Core.Models.Settings;
 using FiveSafesTes.Core.Models.ViewModels;
 using FiveSafesTes.Core.Services;
+using Agent.Api.Helpers;
 using Hangfire;
 using Hangfire.Storage;
 using Microsoft.Extensions.Options;
@@ -98,12 +99,13 @@ public class OnboardingService(
         if (string.IsNullOrEmpty(configSettings.CurrentValue.SubmissionURL))
         {
             Log.Error("OnboardingService:LogIntoSubmissionlayer - SumbissionURL is missing");
+            return;
         }
 
         HttpClient httpClient = new();
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", configSettings.CurrentValue.JWT);
 
-        HttpResponseMessage response = await httpClient.PostAsync($"{configSettings.CurrentValue.SubmissionURL}/api/Onboarding/RetrieveCredentials", null);
+        HttpResponseMessage response = await httpClient.PostAsync(UrlHelper.Combine(configSettings.CurrentValue.SubmissionURL, "api/Onboarding/RetrieveCredentials"), null);
 
         if (response.IsSuccessStatusCode)
         {
@@ -208,7 +210,7 @@ public class OnboardingService(
         try
         {
             using HttpClient client = new();
-            HttpResponseMessage response = client.GetAsync(_apiEndpoints.SubmissionApiUrl + "/api/HealthCheck/CheckHealth").Result;
+            HttpResponseMessage response = client.GetAsync(UrlHelper.Combine(_apiEndpoints.SubmissionApiUrl, "api/HealthCheck/CheckHealth")).Result;
             return response.IsSuccessStatusCode;
         }
         catch (Exception ex)


### PR DESCRIPTION
Previously, concatenating a base address with "/api/..." produced a double slash when the base already ended in "/". This commit:

- Adds Agent.Api/Helpers/UrlHelper.Combine, which normalises the base to a single trailing slash and resolves the relative path against it (also preserving any base path prefix). Route all call sites through it.

- Guards the UrlHelper.Combine against null/empty inputs so a missing base URL fails with a clear ArgumentException rather than an opaque NullReferenceException

### :hammer_and_wrench: Pull Request
<!-- # Delete content types that don't apply to your pull request -->
♻️ Refactor
✨ Feature
🦋 Bug Fix
⚡️ Optimization
📝 Documentation
🛠️ Repo maintenance
#### Description:
A clear and concise description of what you are changing.

## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :paperclip: Have commits been checked for accidental file inclusions?  
