### PR TITLE
feat(helm): add standalone submission chart

### DIFF
--- a/.github/workflows/submission-chart.yaml
+++ b/.github/workflows/submission-chart.yaml
@@ -1,0 +1,40 @@
+name: Build Submission Helm Chart
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/submission-chart.yaml'
+      - 'charts/submission/**'
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/submission-chart.yaml'
+      - 'charts/submission/**'
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  submission-helm-chart:
+    uses: SwanseaUniversityMedical/workflows/.github/workflows/pr-and-release-chart.yaml@v4.0.0-charts
+    with:
+      job-name: submission-helm-chart
+      registry: ${{ vars.HARBOR_FEDA_REGISTRY }}
+      registry-user: ${{ vars.HARBOR_USER }}
+      registry-project: ${{ vars.HARBOR_PROJECT }}
+      registry-repo: submission
+      release-tag-format: 'Submission-Chart-${version}'
+      notation-cert: ${{ vars.NOTATION_CERT }}
+      chart: charts/submission
+      test-command: |
+        helm template $CHART --debug
+    secrets:
+      notation-key: ${{ secrets.NOTATION_KEY }}
+      registry-token: ${{ secrets.HARBOR_TOKEN }}

--- a/Submission/Submission.Api/Program.cs
+++ b/Submission/Submission.Api/Program.cs
@@ -1,3 +1,4 @@
+using Prometheus;
 using Submission.Api.Repositories.DbContexts;
 using Submission.Api.Services.Contract;
 using Submission.Api.Services;
@@ -198,6 +199,16 @@ builder.Services.AddAuthentication(options =>
 builder.Services.AddAuthorization();
 
 var app = builder.Build();
+
+if (Environment.GetEnvironmentVariable("PUSHGATEWAY_URL") != null)
+{
+    var pusher = new MetricPusher(new MetricPusherOptions
+    {
+        Endpoint = Environment.GetEnvironmentVariable("PUSHGATEWAY_URL"),
+        Job = Environment.GetEnvironmentVariable("PUSHGATEWAY_JOB")
+    });
+    pusher.Start();
+}
 
 var serviceScopeFactory = app.Services.GetRequiredService<IServiceScopeFactory>();
 app.MapHealthChecks("/health");

--- a/Submission/Submission.Api/Submission.Api.csproj
+++ b/Submission/Submission.Api/Submission.Api.csproj
@@ -28,6 +28,8 @@
 	<PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="8.0.22" />
 	<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
 	<PackageReference Include="NETCore.MailKit" Version="2.1.0" />
+    <PackageReference Include="prometheus-net" Version="8.2.1" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Enrichers.Demystifier" Version="1.0.2" />

--- a/Submission/Submission.Web/Program.cs
+++ b/Submission/Submission.Web/Program.cs
@@ -1,6 +1,7 @@
 
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Prometheus;
 using System.Net;
 using FiveSafesTes.Core.Models.Services;
 using FiveSafesTes.Core.Models.Settings;
@@ -335,6 +336,17 @@ builder.Services.AddCors(options =>
 });
 
 var app = builder.Build();
+
+if (Environment.GetEnvironmentVariable("PUSHGATEWAY_URL") != null)
+{
+    var pusher = new MetricPusher(new MetricPusherOptions
+    {
+        Endpoint = Environment.GetEnvironmentVariable("PUSHGATEWAY_URL"),
+        Job = Environment.GetEnvironmentVariable("PUSHGATEWAY_JOB")
+    });
+    pusher.Start();
+}
+
 app.UseCors();
 app.UseForwardedHeaders();
 

--- a/Submission/Submission.Web/Submission.Web.csproj
+++ b/Submission/Submission.Web/Submission.Web.csproj
@@ -12,6 +12,8 @@
   <ItemGroup>
     <PackageReference Include="Duende.AccessTokenManagement" Version="4.1.0" />
     <PackageReference Include="Duende.AccessTokenManagement.OpenIdConnect" Version="4.1.0" />
+    <PackageReference Include="prometheus-net" Version="8.2.1" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="bootstrap" Version="5.3.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.22" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.22" />

--- a/charts/submission/Chart.yaml
+++ b/charts/submission/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: submission
+description: Standalone chart for the 5S TES Submission layer API and UI
+type: application
+version: 1.0.0
+appVersion: "3.1.1"

--- a/charts/submission/README.md
+++ b/charts/submission/README.md
@@ -148,7 +148,6 @@ Set by `ui.secretName`.
 | `ui.ingress.host` | Hostname for that Ingress. Must match `global.config.uiRedirectUrl`. | `submission.localtest.me` |
 | `ui.apiAddress` | Address the UI calls the API on. The in-chart service name works unless the API is elsewhere. | `http://submission-api` |
 | `ui.uiName` | Product name shown in the UI. | `Five Safes TES` |
-| `ui.formIoUseInternal` | Use the bundled forms instead of external form.io. | `true` |
 | `ui.frontend.queryImageSql` | Container image reference the SQL query wizard submits as a task. | `harbor.federated-analytics.ac.uk/5s-tes-analysis-tools/5s-tes-analysis-tools-tre-sqlpg:1.0.0` |
 | `ui.frontend.s3BaseUrl` | Browser-facing URL of the S3 console, for output links. | `http://rustfs-submission.localtest.me` |
 | `ui.frontend.s3BucketPath` | Console path template for a bucket link. | `/rustfs/console/browser/?bucket=` |

--- a/charts/submission/README.md
+++ b/charts/submission/README.md
@@ -80,6 +80,13 @@ Set by `ui.secretName`.
 | `dataProtectionStorage.storageClassName` | Storage class for that claim. Must support ReadWriteMany. `null` uses the cluster default. | `null` |
 | `dataProtectionStorage.mountPath` | Where the key ring is mounted. Fixed in the application code; do not change without a matching code change. | `/root/.aspnet/DataProtection-Keys` |
 
+### Monitoring
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `monitoring.enabled` | Push Prometheus metrics from both components to a pushgateway. | `true` |
+| `monitoring.pushgatewayUrl` | Pushgateway address, including the `/metrics` path. | `http://prometheus-pushgateway.hiru-mgmt-monitoring.svc.cluster.local:9091/metrics` |
+
 ### Global parameters
 
 | **Name** | **Description** | **Value** |

--- a/charts/submission/README.md
+++ b/charts/submission/README.md
@@ -32,7 +32,7 @@ Set by `api.secretName`.
 | **Key** | **Used for** | **Required** |
 |---|---|---|
 | `connectionString` | Full PostgreSQL connection string for the `DARE-Control` database, including the password. Read into `ConnectionStrings__DefaultConnection`. | Yes |
-| `keycloakClientSecret` | Client secret for the `Dare-Control-API` Keycloak client. | Yes |
+| `keycloakClientSecret` | Client secret for the client named in `api.keycloak.clientId`. | Yes |
 | `keycloakAdminPassword` | Password for the Keycloak admin account the API uses to create users and clients. Pairs with `api.keycloak.adminUsername`. | Yes |
 | `rabbitPassword` | Password for the RabbitMQ user named in `global.config.rabbitmq.username`. | Yes |
 | `s3AccessKey` | Access key for the Submission object store at `api.s3.url`. | Yes |
@@ -45,7 +45,7 @@ Set by `ui.secretName`.
 
 | **Key** | **Used for** | **Required** |
 |---|---|---|
-| `keycloakClientSecret` | Client secret for the `Dare-Control-UI` Keycloak client. | Yes |
+| `keycloakClientSecret` | Client secret for the client named in `ui.keycloak.clientId`. | Yes |
 
 ## Parameters
 
@@ -98,7 +98,8 @@ Set by `ui.secretName`.
 | `global.ingress.tls` | Render the TLS blocks. Turn off for local clusters with no issuer. | `true` |
 | `global.config.seqUrl` | Address of the Seq instance both components log to. | `http://seq:5341` |
 | `global.config.logLevel` | Serilog minimum level for both components. | `Information` |
-| `global.config.keycloakUrl` | Base URL of the Keycloak that holds the `Dare-Control` realm. Wrong value means nobody can log in. | `http://keycloak.localtest.me:8085` |
+| `global.config.keycloak.url` | Base URL of the Keycloak that holds the Submission (control) realm. Wrong value means nobody can log in. | `http://keycloak.localtest.me:8085` |
+| `global.config.keycloak.realm` | Name of that realm. | `Dare-Control` |
 | `global.config.keycloakDemoMode` | Keycloak demo mode flag. Keep off outside demos. | `false` |
 | `global.config.uiRedirectUrl` | Public URL of the UI. Keycloak sends browsers back here after login; must match the UI ingress host. | `http://submission.localtest.me` |
 | `global.config.suppressAntiforgery` | Disables anti-forgery tokens and switches Data Protection onto the shared claim. Testing only. | `false` |
@@ -127,6 +128,8 @@ Set by `ui.secretName`.
 | `api.ingress.enabled` | Create an Ingress for the API. | `true` |
 | `api.ingress.host` | Hostname for that Ingress. | `submission-api.localtest.me` |
 | `api.publicUrl` | Public URL of this API. Embedded in TRE onboarding data, so remote agent hosts must be able to reach it. An in-cluster name breaks onboarding. | `http://submission-api.localtest.me` |
+| `api.keycloak.clientId` | Keycloak client the API authenticates as. | `Dare-Control-API` |
+| `api.keycloak.validAudiences` | Audiences accepted in tokens. | `Dare-Control-UI,Dare-Control-API,Dare-Control-Minio` |
 | `api.keycloak.server` | Keycloak host, as the API validates issuers against it. | `keycloak.localtest.me` |
 | `api.keycloak.protocol` | Scheme for that host. | `http` |
 | `api.keycloak.validIssuer` | Exact issuer string expected in tokens. Wrong value rejects every login. | `http://keycloak.localtest.me:8085/realms/Dare-Control` |
@@ -153,6 +156,7 @@ Set by `ui.secretName`.
 | `ui.secretName` | Name of the Kubernetes Secret holding the UI secrets. See **Secrets**. | `submission-ui-secret` |
 | `ui.ingress.enabled` | Create an Ingress for the UI. | `true` |
 | `ui.ingress.host` | Hostname for that Ingress. Must match `global.config.uiRedirectUrl`. | `submission.localtest.me` |
+| `ui.keycloak.clientId` | Keycloak client the UI logs users in with. | `Dare-Control-UI` |
 | `ui.apiAddress` | Address the UI calls the API on. The in-chart service name works unless the API is elsewhere. | `http://submission-api` |
 | `ui.uiName` | Product name shown in the UI. | `Five Safes TES` |
 | `ui.frontend.queryImageSql` | Container image reference the SQL query wizard submits as a task. | `harbor.federated-analytics.ac.uk/5s-tes-analysis-tools/5s-tes-analysis-tools-tre-sqlpg:1.0.0` |

--- a/charts/submission/README.md
+++ b/charts/submission/README.md
@@ -1,0 +1,154 @@
+# submission
+
+Standalone chart for the 5S TES Submission layer.
+
+## What this chart deploys
+
+- `api` — Submission.Api, the researcher-facing submission API. Also consumes RabbitMQ messages and provisions per-project S3 users.
+- `ui` — Submission.Web, the MVC frontend for the API.
+
+## What must already exist
+
+- The Secrets listed below, in the release namespace.
+- A ConfigMap holding the cluster CA bundle (see `trustClusterCa`).
+- A ReadWriteMany-capable storage class for the shared Data Protection claim.
+
+## What this chart does not do
+
+It does not install PostgreSQL, Keycloak, RabbitMQ, Vault, Seq or the S3
+object store. It expects their addresses as values. The `submission-stack`
+chart installs those and points this chart at them.
+
+## Secrets
+
+This chart does **not** create these. They must already exist in the
+namespace before the chart is installed. In our deployments the
+`submission-stack` chart creates them from Vault.
+
+### `submission-api-secret`
+
+Set by `api.secretName`.
+
+| **Key** | **Used for** | **Required** |
+|---|---|---|
+| `connectionString` | Full PostgreSQL connection string for the `DARE-Control` database, including the password. Read into `ConnectionStrings__DefaultConnection`. | Yes |
+| `keycloakClientSecret` | Client secret for the `Dare-Control-API` Keycloak client. | Yes |
+| `keycloakAdminPassword` | Password for the Keycloak admin account the API uses to create users and clients. Pairs with `api.keycloak.adminUsername`. | Yes |
+| `rabbitPassword` | Password for the RabbitMQ user named in `global.config.rabbitmq.username`. | Yes |
+| `s3AccessKey` | Access key for the Submission object store at `api.s3.url`. | Yes |
+| `s3SecretKey` | Secret key matching `s3AccessKey`. | Yes |
+| `vaultToken` | Token for the Vault at `global.config.vault.url`, used to store per-project S3 credentials. | Yes |
+
+### `submission-ui-secret`
+
+Set by `ui.secretName`.
+
+| **Key** | **Used for** | **Required** |
+|---|---|---|
+| `keycloakClientSecret` | Client secret for the `Dare-Control-UI` Keycloak client. | Yes |
+
+## Parameters
+
+### Common parameters
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `nameOverride` | Replaces the chart name in object names. | `""` |
+| `fullnameOverride` | Replaces the full prefix on every object name. The stack chart sets this so service DNS names stay predictable. | `"submission"` |
+| `imagePullSecrets` | Secrets used to pull images from a private registry. | `[]` |
+| `serviceAccount.create` | Create a service account for the pods. | `true` |
+| `serviceAccount.annotations` | Annotations for the service account. | `{}` |
+| `serviceAccount.name` | Use an existing service account name instead. | `""` |
+| `podSecurityContext.fsGroup` | Group that owns mounted volumes, so the non-root app user can write the shared key ring. | `1000` |
+| `securityContext.*` | Organisation security baseline (non-root, read-only filesystem, no capabilities). Do not weaken without a reason in the pull request. | see values |
+
+### Certificate trust
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `trustClusterCa.enabled` | Mount a cluster CA bundle over the container trust store. Turn off only on a cluster that has no such bundle. | `true` |
+| `trustClusterCa.configMapName` | ConfigMap holding the bundle. Provided by the cluster, not by this chart. | `overlay-castore` |
+| `trustClusterCa.key` | Key inside that ConfigMap. Also used as the mount `subPath`. | `ca-certificates.crt` |
+| `trustClusterCa.mountPath` | File replaced inside the container. Correct for Debian, Ubuntu and Alpine images. | `/etc/ssl/certs/ca-certificates.crt` |
+
+### Storage
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `persistentVolumeLabels` | Labels put on every PersistentVolumeClaim, for the cluster backup tool. Set `{}` for none. | `hiru.io/backup: "enabled"` |
+| `dataProtectionStorage.size` | Size of the shared ASP.NET Data Protection key claim. | `1Gi` |
+| `dataProtectionStorage.storageClassName` | Storage class for that claim. Must support ReadWriteMany. `null` uses the cluster default. | `null` |
+| `dataProtectionStorage.mountPath` | Where the key ring is mounted. Fixed in the application code; do not change without a matching code change. | `/root/.aspnet/DataProtection-Keys` |
+
+### Global parameters
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `global.tag` | Image tag used by any component that does not pin its own. | `latest` |
+| `global.ingress.enabled` | Master switch for every Ingress in the chart. | `true` |
+| `global.ingress.className` | Ingress controller class. | `nginx` |
+| `global.ingress.certClusterIssuer` | cert-manager ClusterIssuer that issues the TLS certificates. | `ca-issuer` |
+| `global.ingress.tls` | Render the TLS blocks. Turn off for local clusters with no issuer. | `true` |
+| `global.config.seqUrl` | Address of the Seq instance both components log to. | `http://seq:5341` |
+| `global.config.logLevel` | Serilog minimum level for both components. | `Information` |
+| `global.config.keycloakUrl` | Base URL of the Keycloak that holds the `Dare-Control` realm. Wrong value means nobody can log in. | `http://keycloak.localtest.me:8085` |
+| `global.config.keycloakDemoMode` | Keycloak demo mode flag. Keep off outside demos. | `false` |
+| `global.config.uiRedirectUrl` | Public URL of the UI. Keycloak sends browsers back here after login; must match the UI ingress host. | `http://submission.localtest.me` |
+| `global.config.suppressAntiforgery` | Disables anti-forgery tokens and switches Data Protection onto the shared claim. Testing only. | `false` |
+| `global.config.sslCookies` | Mark auth cookies secure. Needs HTTPS end to end. | `false` |
+| `global.config.httpsRedirect` | Redirect HTTP to HTTPS inside the app. Usually off behind an ingress that already does this. | `false` |
+| `global.config.rabbitmq.host` | RabbitMQ host both components use. | `rabbitmq` |
+| `global.config.rabbitmq.username` | RabbitMQ username. Password comes from the API secret. | `rabbitmq` |
+| `global.config.vault.url` | Address of the Vault the API stores per-project S3 credentials in. | `http://vault:8200` |
+| `global.config.proxy.enabled` | Route Keycloak HTTP calls through a proxy. | `false` |
+| `global.config.proxy.url` | Proxy address, when enabled. | `""` |
+| `global.config.proxy.bypass` | Comma-separated hosts that skip the proxy. | `submission-api,seq` |
+
+### API parameters
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `api.enabled` | Deploy the API component. | `true` |
+| `api.image.repository` | Image for the API. | `harbor.federated-analytics.ac.uk/5s-tes/submission-api` |
+| `api.image.tag` | Image tag. Falls back to `global.tag` when empty. | `""` |
+| `api.image.pullPolicy` | Image pull policy. | `IfNotPresent` |
+| `api.replicas` | Number of copies. | `1` |
+| `api.containerPort` | Port the ASP.NET app listens on. Describes the app; it does not change it. | `8080` |
+| `api.resources` | CPU and memory requests/limits. | `{}` |
+| `api.service.type` | Service type. | `ClusterIP` |
+| `api.secretName` | Name of the Kubernetes Secret holding the API secrets. See **Secrets**. | `submission-api-secret` |
+| `api.ingress.enabled` | Create an Ingress for the API. | `true` |
+| `api.ingress.host` | Hostname for that Ingress. | `submission-api.localtest.me` |
+| `api.publicUrl` | Public URL of this API. Embedded in TRE onboarding data, so remote agent hosts must be able to reach it. An in-cluster name breaks onboarding. | `http://submission-api.localtest.me` |
+| `api.keycloak.server` | Keycloak host, as the API validates issuers against it. | `keycloak.localtest.me` |
+| `api.keycloak.protocol` | Scheme for that host. | `http` |
+| `api.keycloak.validIssuer` | Exact issuer string expected in tokens. Wrong value rejects every login. | `http://keycloak.localtest.me:8085/realms/Dare-Control` |
+| `api.keycloak.autoTrustKeycloakCert` | Trust a self-signed Keycloak certificate. Prefer `trustClusterCa` instead. | `false` |
+| `api.keycloak.signedOutRedirectUri` | Where browsers land after sign-out. | `http://submission.localtest.me` |
+| `api.keycloak.tokenRefreshSeconds` | Token refresh interval. | `300` |
+| `api.keycloak.adminUsername` | Keycloak admin account used to create users and clients. | `admin` |
+| `api.s3.url` | Address of the Submission object store. | `http://rustfs-submission:9000` |
+| `api.s3.adminConsole` | Address of that store's admin console. | `http://rustfs-submission:9001` |
+| `api.seedDemoData` | Seed demo data on start. Demos only. | `false` |
+
+### UI parameters
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `ui.enabled` | Deploy the UI component. | `true` |
+| `ui.image.repository` | Image for the UI. | `harbor.federated-analytics.ac.uk/5s-tes/submission-ui` |
+| `ui.image.tag` | Image tag. Falls back to `global.tag` when empty. | `""` |
+| `ui.image.pullPolicy` | Image pull policy. | `IfNotPresent` |
+| `ui.replicas` | Number of copies. | `1` |
+| `ui.containerPort` | Port the ASP.NET app listens on. | `8080` |
+| `ui.resources` | CPU and memory requests/limits. | `{}` |
+| `ui.service.type` | Service type. | `ClusterIP` |
+| `ui.secretName` | Name of the Kubernetes Secret holding the UI secrets. See **Secrets**. | `submission-ui-secret` |
+| `ui.ingress.enabled` | Create an Ingress for the UI. | `true` |
+| `ui.ingress.host` | Hostname for that Ingress. Must match `global.config.uiRedirectUrl`. | `submission.localtest.me` |
+| `ui.apiAddress` | Address the UI calls the API on. The in-chart service name works unless the API is elsewhere. | `http://submission-api` |
+| `ui.uiName` | Product name shown in the UI. | `Five Safes TES` |
+| `ui.formIoUseInternal` | Use the bundled forms instead of external form.io. | `true` |
+| `ui.frontend.queryImageSql` | Container image reference the SQL query wizard submits as a task. | `harbor.federated-analytics.ac.uk/5s-tes-analysis-tools/5s-tes-analysis-tools-tre-sqlpg:1.0.0` |
+| `ui.frontend.s3BaseUrl` | Browser-facing URL of the S3 console, for output links. | `http://rustfs-submission.localtest.me` |
+| `ui.frontend.s3BucketPath` | Console path template for a bucket link. | `/rustfs/console/browser/?bucket=` |

--- a/charts/submission/README.md
+++ b/charts/submission/README.md
@@ -91,7 +91,7 @@ Set by `ui.secretName`.
 
 | **Name** | **Description** | **Value** |
 |---|---|---|
-| `global.tag` | Image tag used by any component that does not pin its own. | `latest` |
+| `global.tag` | Image tag used by any component that does not pin its own. | `3.1.1` |
 | `global.ingress.enabled` | Master switch for every Ingress in the chart. | `true` |
 | `global.ingress.className` | Ingress controller class. | `nginx` |
 | `global.ingress.certClusterIssuer` | cert-manager ClusterIssuer that issues the TLS certificates. | `ca-issuer` |
@@ -122,7 +122,7 @@ Set by `ui.secretName`.
 | `api.image.pullPolicy` | Image pull policy. | `IfNotPresent` |
 | `api.replicas` | Number of copies. | `1` |
 | `api.containerPort` | Port the ASP.NET app listens on. Describes the app; it does not change it. | `8080` |
-| `api.resources` | CPU and memory requests/limits. | `{}` |
+| `api.resources` | Resource requests and limits. Defaults set modest requests and memory/storage limits. | see `values.yaml` |
 | `api.service.type` | Service type. | `ClusterIP` |
 | `api.secretName` | Name of the Kubernetes Secret holding the API secrets. See **Secrets**. | `submission-api-secret` |
 | `api.ingress.enabled` | Create an Ingress for the API. | `true` |
@@ -151,7 +151,7 @@ Set by `ui.secretName`.
 | `ui.image.pullPolicy` | Image pull policy. | `IfNotPresent` |
 | `ui.replicas` | Number of copies. | `1` |
 | `ui.containerPort` | Port the ASP.NET app listens on. | `8080` |
-| `ui.resources` | CPU and memory requests/limits. | `{}` |
+| `ui.resources` | Resource requests and limits. Defaults set modest requests and memory/storage limits. | see `values.yaml` |
 | `ui.service.type` | Service type. | `ClusterIP` |
 | `ui.secretName` | Name of the Kubernetes Secret holding the UI secrets. See **Secrets**. | `submission-ui-secret` |
 | `ui.ingress.enabled` | Create an Ingress for the UI. | `true` |

--- a/charts/submission/templates/_helpers.tpl
+++ b/charts/submission/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "submission.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncated at 63 characters because Kubernetes name fields are limited to this.
+*/}}
+{{- define "submission.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name and version, used by the chart label.
+*/}}
+{{- define "submission.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "submission.labels" -}}
+helm.sh/chart: {{ include "submission.chart" . }}
+{{ include "submission.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "submission.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "submission.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service account name to use.
+*/}}
+{{- define "submission.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "submission.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/submission/templates/api/deployment.yaml
+++ b/charts/submission/templates/api/deployment.yaml
@@ -75,6 +75,12 @@ spec:
               port: http
             initialDelaySeconds: 5
           env:
+            {{- if .Values.monitoring.enabled }}
+            - name: PUSHGATEWAY_URL
+              value: "{{ .Values.monitoring.pushgatewayUrl }}"
+            - name: PUSHGATEWAY_JOB
+              value: {{ .Release.Namespace }}-{{ include "submission.fullname" . }}-api
+            {{- end }}
             - name: Serilog__SeqServerUrl
               value: "{{ .Values.global.config.seqUrl }}"
             - name: Serilog__MinimumLevel__Default

--- a/charts/submission/templates/api/deployment.yaml
+++ b/charts/submission/templates/api/deployment.yaml
@@ -135,22 +135,22 @@ spec:
             - name: SubmissionKeyCloakSettings__BypassProxy
               value: "{{ .Values.global.config.proxy.bypass }}"
             - name: SubmissionKeyCloakSettings__Authority
-              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control/"
+              value: "{{ .Values.global.config.keycloak.url }}/realms/{{ .Values.global.config.keycloak.realm }}/"
             - name: SubmissionKeyCloakSettings__BaseUrl
-              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control"
+              value: "{{ .Values.global.config.keycloak.url }}/realms/{{ .Values.global.config.keycloak.realm }}"
             - name: SubmissionKeyCloakSettings__MetadataAddress
-              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control/.well-known/openid-configuration"
+              value: "{{ .Values.global.config.keycloak.url }}/realms/{{ .Values.global.config.keycloak.realm }}/.well-known/openid-configuration"
             - name: SubmissionKeyCloakSettings__ClientId
-              value: "Dare-Control-API"
+              value: "{{ .Values.api.keycloak.clientId }}"
             - name: SubmissionKeyCloakSettings__ClientSecret
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.api.secretName }}
                   key: keycloakClientSecret
             - name: SubmissionKeyCloakSettings__ValidAudiences
-              value: "Dare-Control-UI,Dare-Control-API,Dare-Control-Minio"
+              value: "{{ .Values.api.keycloak.validAudiences }}"
             - name: SubmissionKeyCloakSettings__Realm
-              value: "Dare-Control"
+              value: "{{ .Values.global.config.keycloak.realm }}"
             - name: SubmissionKeyCloakSettings__Server
               value: "{{ .Values.api.keycloak.server }}"
             - name: SubmissionKeyCloakSettings__Protocol

--- a/charts/submission/templates/api/deployment.yaml
+++ b/charts/submission/templates/api/deployment.yaml
@@ -1,0 +1,177 @@
+{{- if .Values.api.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "submission.fullname" . }}-api
+  labels:
+    {{- include "submission.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.api.replicas }}
+  selector:
+    matchLabels:
+      {{- include "submission.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        {{- include "submission.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+    spec:
+      serviceAccountName: {{ include "submission.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        {{- if .Values.trustClusterCa.enabled }}
+        - name: certs-overlay
+          configMap:
+            name: {{ .Values.trustClusterCa.configMapName }}
+            defaultMode: 420
+        {{- end }}
+        # The app writes its Data Protection keys under /root, but runs as a
+        # non-root user that cannot enter /root. The emptyDir makes /root
+        # traversable; the keys themselves live on the shared claim below.
+        - name: root-home
+          emptyDir: {}
+        - name: data-protection
+          persistentVolumeClaim:
+            claimName: {{ include "submission.fullname" . }}-data-protection
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: api
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Values.global.tag }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          volumeMounts:
+            {{- if .Values.trustClusterCa.enabled }}
+            - name: certs-overlay
+              mountPath: {{ .Values.trustClusterCa.mountPath }}
+              subPath: {{ .Values.trustClusterCa.key }}
+            {{- end }}
+            - name: root-home
+              mountPath: /root
+            - name: data-protection
+              mountPath: {{ .Values.dataProtectionStorage.mountPath }}
+            - name: tmp
+              mountPath: /tmp
+          ports:
+            - name: http
+              containerPort: {{ .Values.api.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+          env:
+            - name: Serilog__SeqServerUrl
+              value: "{{ .Values.global.config.seqUrl }}"
+            - name: Serilog__MinimumLevel__Default
+              value: "{{ .Values.global.config.logLevel }}"
+            - name: Logging__LogLevel__Default
+              value: "{{ .Values.global.config.logLevel }}"
+            - name: KeycloakDemoMode
+              value: "{{ .Values.global.config.keycloakDemoMode }}"
+            - name: SuppressAntiforgery
+              value: "{{ .Values.global.config.suppressAntiforgery }}"
+            - name: Features__SeedDemoData
+              value: "{{ .Values.api.seedDemoData }}"
+            - name: ConnectionStrings__DefaultConnection
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: connectionString
+            - name: RabbitMQ__HostAddress
+              value: "{{ .Values.global.config.rabbitmq.host }}"
+            - name: RabbitMQ__Username
+              value: "{{ .Values.global.config.rabbitmq.username }}"
+            - name: RabbitMQ__Password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: rabbitPassword
+            - name: MinioSettings__Url
+              value: "{{ .Values.api.s3.url }}"
+            - name: MinioSettings__AdminConsole
+              value: "{{ .Values.api.s3.adminConsole }}"
+            - name: MinioSettings__AccessKey
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: s3AccessKey
+            - name: MinioSettings__SecretKey
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: s3SecretKey
+            - name: VaultSettings__BaseUrl
+              value: "{{ .Values.global.config.vault.url }}"
+            - name: VaultSettings__Token
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: vaultToken
+            - name: SubmissionKeyCloakSettings__Proxy
+              value: "{{ .Values.global.config.proxy.enabled }}"
+            - name: SubmissionKeyCloakSettings__ProxyAddresURL
+              value: "{{ .Values.global.config.proxy.url }}"
+            - name: SubmissionKeyCloakSettings__BypassProxy
+              value: "{{ .Values.global.config.proxy.bypass }}"
+            - name: SubmissionKeyCloakSettings__Authority
+              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control/"
+            - name: SubmissionKeyCloakSettings__BaseUrl
+              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control"
+            - name: SubmissionKeyCloakSettings__MetadataAddress
+              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control/.well-known/openid-configuration"
+            - name: SubmissionKeyCloakSettings__ClientId
+              value: "Dare-Control-API"
+            - name: SubmissionKeyCloakSettings__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: keycloakClientSecret
+            - name: SubmissionKeyCloakSettings__ValidAudiences
+              value: "Dare-Control-UI,Dare-Control-API,Dare-Control-Minio"
+            - name: SubmissionKeyCloakSettings__Realm
+              value: "Dare-Control"
+            - name: SubmissionKeyCloakSettings__Server
+              value: "{{ .Values.api.keycloak.server }}"
+            - name: SubmissionKeyCloakSettings__Protocol
+              value: "{{ .Values.api.keycloak.protocol }}"
+            - name: SubmissionKeyCloakSettings__ValidIssuer
+              value: "{{ .Values.api.keycloak.validIssuer }}"
+            - name: SubmissionKeyCloakSettings__AutoTrustKeycloakCert
+              value: "{{ .Values.api.keycloak.autoTrustKeycloakCert }}"
+            - name: SubmissionKeyCloakSettings__UseRedirectURL
+              value: "false"
+            - name: SubmissionKeyCloakSettings__RedirectURL
+              value: "{{ .Values.global.config.uiRedirectUrl }}"
+            - name: SubmissionKeyCloakSettings__TokenExpiredAddress
+              value: "{{ .Values.global.config.uiRedirectUrl }}/Account/LoginAfterTokenExpired"
+            - name: SubmissionKeyCloakSettings__SignedOutRedirectUri
+              value: "{{ .Values.api.keycloak.signedOutRedirectUri }}"
+            - name: SubmissionKeyCloakSettings__TokenRefreshSeconds
+              value: "{{ .Values.api.keycloak.tokenRefreshSeconds }}"
+            - name: KeycloakAdmin__Username
+              value: "{{ .Values.api.keycloak.adminUsername }}"
+            - name: KeycloakAdmin__Password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: keycloakAdminPassword
+            - name: SubmissionApiUrl
+              value: "{{ .Values.api.publicUrl }}"
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+{{- end }}

--- a/charts/submission/templates/api/deployment.yaml
+++ b/charts/submission/templates/api/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: api
     spec:
       serviceAccountName: {{ include "submission.serviceAccountName" . }}
+      automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/submission/templates/api/ingress.yaml
+++ b/charts/submission/templates/api/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.api.enabled .Values.api.ingress.enabled .Values.global.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "submission.fullname" . }}-api
+  labels:
+    {{- include "submission.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.global.ingress.certClusterIssuer }}
+    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+spec:
+  ingressClassName: {{ .Values.global.ingress.className }}
+  {{- if .Values.global.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.api.ingress.host }}
+      secretName: {{ include "submission.fullname" . }}-api-tls
+  {{- end }}
+  rules:
+    - host: {{ .Values.api.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "submission.fullname" . }}-api
+                port:
+                  number: 80
+{{- end }}

--- a/charts/submission/templates/api/service.yaml
+++ b/charts/submission/templates/api/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.api.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "submission.fullname" . }}-api
+  labels:
+    {{- include "submission.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  type: {{ .Values.api.service.type }}
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "submission.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+{{- end }}

--- a/charts/submission/templates/pvc-data-protection.yaml
+++ b/charts/submission/templates/pvc-data-protection.yaml
@@ -1,0 +1,21 @@
+{{- if or .Values.api.enabled .Values.ui.enabled -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "submission.fullname" . }}-data-protection
+  labels:
+    {{- include "submission.labels" . | nindent 4 }}
+    {{- with .Values.persistentVolumeLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if typeIs "string" .Values.dataProtectionStorage.storageClassName }}
+  storageClassName: {{ .Values.dataProtectionStorage.storageClassName | quote }}
+  {{- end }}
+  # ReadWriteMany: the API and UI pods both read and write the key ring.
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.dataProtectionStorage.size | quote }}
+{{- end }}

--- a/charts/submission/templates/serviceaccount.yaml
+++ b/charts/submission/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "submission.serviceAccountName" . }}
+  labels:
+    {{- include "submission.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/submission/templates/ui/deployment.yaml
+++ b/charts/submission/templates/ui/deployment.yaml
@@ -114,15 +114,15 @@ spec:
             - name: SubmissionKeyCloakSettings__BypassProxy
               value: "{{ .Values.global.config.proxy.bypass }}"
             - name: SubmissionKeyCloakSettings__Authority
-              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control/"
+              value: "{{ .Values.global.config.keycloak.url }}/realms/{{ .Values.global.config.keycloak.realm }}/"
             - name: SubmissionKeyCloakSettings__BaseUrl
-              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control"
+              value: "{{ .Values.global.config.keycloak.url }}/realms/{{ .Values.global.config.keycloak.realm }}"
             - name: SubmissionKeyCloakSettings__MetadataAddress
-              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control/.well-known/openid-configuration"
+              value: "{{ .Values.global.config.keycloak.url }}/realms/{{ .Values.global.config.keycloak.realm }}/.well-known/openid-configuration"
             - name: SubmissionKeyCloakSettings__AccountManagementURL
-              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control/account"
+              value: "{{ .Values.global.config.keycloak.url }}/realms/{{ .Values.global.config.keycloak.realm }}/account"
             - name: SubmissionKeyCloakSettings__ClientId
-              value: "Dare-Control-UI"
+              value: "{{ .Values.ui.keycloak.clientId }}"
             - name: SubmissionKeyCloakSettings__ClientSecret
               valueFrom:
                 secretKeyRef:

--- a/charts/submission/templates/ui/deployment.yaml
+++ b/charts/submission/templates/ui/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: ui
     spec:
       serviceAccountName: {{ include "submission.serviceAccountName" . }}
+      automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/submission/templates/ui/deployment.yaml
+++ b/charts/submission/templates/ui/deployment.yaml
@@ -95,8 +95,6 @@ spec:
               value: "{{ .Values.ui.apiAddress }}"
             - name: DareAPISettings__HelpAddress
               value: "{{ .Values.ui.apiAddress }}"
-            - name: FormIOSettings__UseInternal
-              value: "{{ .Values.ui.formIoUseInternal }}"
             - name: URLSettingsFrontEnd__QueryImageSQL
               value: "{{ .Values.ui.frontend.queryImageSql }}"
             - name: URLSettingsFrontEnd__S3BaseUrl

--- a/charts/submission/templates/ui/deployment.yaml
+++ b/charts/submission/templates/ui/deployment.yaml
@@ -1,0 +1,135 @@
+{{- if .Values.ui.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "submission.fullname" . }}-ui
+  labels:
+    {{- include "submission.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+spec:
+  replicas: {{ .Values.ui.replicas }}
+  selector:
+    matchLabels:
+      {{- include "submission.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ui
+  template:
+    metadata:
+      labels:
+        {{- include "submission.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ui
+    spec:
+      serviceAccountName: {{ include "submission.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        {{- if .Values.trustClusterCa.enabled }}
+        - name: certs-overlay
+          configMap:
+            name: {{ .Values.trustClusterCa.configMapName }}
+            defaultMode: 420
+        {{- end }}
+        # The app writes its Data Protection keys under /root, but runs as a
+        # non-root user that cannot enter /root. The emptyDir makes /root
+        # traversable; the keys themselves live on the shared claim below.
+        - name: root-home
+          emptyDir: {}
+        - name: data-protection
+          persistentVolumeClaim:
+            claimName: {{ include "submission.fullname" . }}-data-protection
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: ui
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Values.global.tag }}"
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          volumeMounts:
+            {{- if .Values.trustClusterCa.enabled }}
+            - name: certs-overlay
+              mountPath: {{ .Values.trustClusterCa.mountPath }}
+              subPath: {{ .Values.trustClusterCa.key }}
+            {{- end }}
+            - name: root-home
+              mountPath: /root
+            - name: data-protection
+              mountPath: {{ .Values.dataProtectionStorage.mountPath }}
+            - name: tmp
+              mountPath: /tmp
+          ports:
+            - name: http
+              containerPort: {{ .Values.ui.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+          env:
+            - name: UIName__Name
+              value: "{{ .Values.ui.uiName }}"
+            - name: Serilog__SeqServerUrl
+              value: "{{ .Values.global.config.seqUrl }}"
+            - name: Serilog__MinimumLevel__Default
+              value: "{{ .Values.global.config.logLevel }}"
+            - name: Logging__LogLevel__Default
+              value: "{{ .Values.global.config.logLevel }}"
+            - name: KeycloakDemoMode
+              value: "{{ .Values.global.config.keycloakDemoMode }}"
+            - name: SuppressAntiforgery
+              value: "{{ .Values.global.config.suppressAntiforgery }}"
+            - name: sslcookies
+              value: "{{ .Values.global.config.sslCookies }}"
+            - name: httpsRedirect
+              value: "{{ .Values.global.config.httpsRedirect }}"
+            - name: DareAPISettings__Address
+              value: "{{ .Values.ui.apiAddress }}"
+            - name: DareAPISettings__HelpAddress
+              value: "{{ .Values.ui.apiAddress }}"
+            - name: FormIOSettings__UseInternal
+              value: "{{ .Values.ui.formIoUseInternal }}"
+            - name: URLSettingsFrontEnd__QueryImageSQL
+              value: "{{ .Values.ui.frontend.queryImageSql }}"
+            - name: URLSettingsFrontEnd__S3BaseUrl
+              value: "{{ .Values.ui.frontend.s3BaseUrl }}"
+            - name: URLSettingsFrontEnd__S3BucketPath
+              value: "{{ .Values.ui.frontend.s3BucketPath }}"
+            - name: SubmissionKeyCloakSettings__Proxy
+              value: "{{ .Values.global.config.proxy.enabled }}"
+            - name: SubmissionKeyCloakSettings__ProxyAddresURL
+              value: "{{ .Values.global.config.proxy.url }}"
+            - name: SubmissionKeyCloakSettings__BypassProxy
+              value: "{{ .Values.global.config.proxy.bypass }}"
+            - name: SubmissionKeyCloakSettings__Authority
+              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control/"
+            - name: SubmissionKeyCloakSettings__BaseUrl
+              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control"
+            - name: SubmissionKeyCloakSettings__MetadataAddress
+              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control/.well-known/openid-configuration"
+            - name: SubmissionKeyCloakSettings__AccountManagementURL
+              value: "{{ .Values.global.config.keycloakUrl }}/realms/Dare-Control/account"
+            - name: SubmissionKeyCloakSettings__ClientId
+              value: "Dare-Control-UI"
+            - name: SubmissionKeyCloakSettings__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ui.secretName }}
+                  key: keycloakClientSecret
+            - name: SubmissionKeyCloakSettings__UseRedirectURL
+              value: "false"
+            - name: SubmissionKeyCloakSettings__RedirectURL
+              value: "{{ .Values.global.config.uiRedirectUrl }}"
+            - name: SubmissionKeyCloakSettings__TokenExpiredAddress
+              value: "{{ .Values.global.config.uiRedirectUrl }}/Account/LoginAfterTokenExpired"
+          resources:
+            {{- toYaml .Values.ui.resources | nindent 12 }}
+{{- end }}

--- a/charts/submission/templates/ui/deployment.yaml
+++ b/charts/submission/templates/ui/deployment.yaml
@@ -75,6 +75,12 @@ spec:
               port: http
             initialDelaySeconds: 5
           env:
+            {{- if .Values.monitoring.enabled }}
+            - name: PUSHGATEWAY_URL
+              value: "{{ .Values.monitoring.pushgatewayUrl }}"
+            - name: PUSHGATEWAY_JOB
+              value: {{ .Release.Namespace }}-{{ include "submission.fullname" . }}-ui
+            {{- end }}
             - name: UIName__Name
               value: "{{ .Values.ui.uiName }}"
             - name: Serilog__SeqServerUrl

--- a/charts/submission/templates/ui/ingress.yaml
+++ b/charts/submission/templates/ui/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.ui.enabled .Values.ui.ingress.enabled .Values.global.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "submission.fullname" . }}-ui
+  labels:
+    {{- include "submission.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.global.ingress.certClusterIssuer }}
+    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+spec:
+  ingressClassName: {{ .Values.global.ingress.className }}
+  {{- if .Values.global.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.ui.ingress.host }}
+      secretName: {{ include "submission.fullname" . }}-ui-tls
+  {{- end }}
+  rules:
+    - host: {{ .Values.ui.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "submission.fullname" . }}-ui
+                port:
+                  number: 80
+{{- end }}

--- a/charts/submission/templates/ui/service.yaml
+++ b/charts/submission/templates/ui/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.ui.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "submission.fullname" . }}-ui
+  labels:
+    {{- include "submission.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+spec:
+  type: {{ .Values.ui.service.type }}
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "submission.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+{{- end }}

--- a/charts/submission/values.yaml
+++ b/charts/submission/values.yaml
@@ -59,7 +59,7 @@ monitoring:
 
 global:
   # Image tag used when a component does not pin its own.
-  tag: "latest"
+  tag: "3.1.1"
 
   ingress:
     enabled: true
@@ -104,7 +104,14 @@ api:
   replicas: 1
   # Must match the port the ASP.NET app listens on inside the container.
   containerPort: 8080
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+      ephemeral-storage: 256Mi
+    limits:
+      memory: 1Gi
+      ephemeral-storage: 1Gi
   service:
     type: ClusterIP
   secretName: submission-api-secret
@@ -137,7 +144,14 @@ ui:
     pullPolicy: IfNotPresent
   replicas: 1
   containerPort: 8080
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+      ephemeral-storage: 256Mi
+    limits:
+      memory: 1Gi
+      ephemeral-storage: 1Gi
   service:
     type: ClusterIP
   secretName: submission-ui-secret

--- a/charts/submission/values.yaml
+++ b/charts/submission/values.yaml
@@ -71,8 +71,10 @@ global:
   config:
     seqUrl: "http://seq:5341"
     logLevel: "Information"
-    # Base URL of the Keycloak that holds the Dare-Control realm.
-    keycloakUrl: "http://keycloak.localtest.me:8085"
+    # Keycloak that holds the Submission (control) realm.
+    keycloak:
+      url: "http://keycloak.localtest.me:8085"
+      realm: "Dare-Control"
     keycloakDemoMode: false
     # Public URL of the Submission UI; Keycloak redirects browsers back here.
     uiRedirectUrl: "http://submission.localtest.me"
@@ -113,6 +115,8 @@ api:
   # must be reachable from remote agent/TRE hosts, not an in-cluster name.
   publicUrl: "http://submission-api.localtest.me"
   keycloak:
+    clientId: "Dare-Control-API"
+    validAudiences: "Dare-Control-UI,Dare-Control-API,Dare-Control-Minio"
     server: "keycloak.localtest.me"
     protocol: "http"
     validIssuer: "http://keycloak.localtest.me:8085/realms/Dare-Control"
@@ -142,6 +146,8 @@ ui:
     host: "submission.localtest.me"
   apiAddress: "http://submission-api"
   uiName: "Five Safes TES"
+  keycloak:
+    clientId: "Dare-Control-UI"
   frontend:
     queryImageSql: "harbor.federated-analytics.ac.uk/5s-tes-analysis-tools/5s-tes-analysis-tools-tre-sqlpg:1.0.0"
     # Browser-facing URL of the S3 console.

--- a/charts/submission/values.yaml
+++ b/charts/submission/values.yaml
@@ -1,0 +1,145 @@
+# Default values for the standalone `submission` chart.
+# The submission-stack chart overrides these through an ArgoCD `Application`.
+# The defaults below are local development settings, so that
+# `helm template ./charts/submission` renders without any extra input.
+
+nameOverride: ""
+# The stack sets this so that service DNS names stay `submission-<component>`.
+fullnameOverride: "submission"
+
+imagePullSecrets: []
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podSecurityContext:
+  fsGroup: 1000
+
+# Organisation security baseline. Do not weaken this without a reason
+# written in the pull request.
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+# Mounts a cluster certificate bundle over every container's trust store, so
+# the apps trust internal HTTPS addresses. The ConfigMap is provided by the
+# cluster, not created by this chart.
+trustClusterCa:
+  enabled: true
+  configMapName: overlay-castore
+  key: ca-certificates.crt
+  mountPath: /etc/ssl/certs/ca-certificates.crt
+
+# Labels put on every PersistentVolumeClaim. The cluster's backup tool uses
+# these to decide what to back up; the labels alone do nothing.
+persistentVolumeLabels:
+  hiru.io/backup: "enabled"
+
+# ASP.NET Data Protection key ring, shared read-write by the API and the UI so
+# that each can decrypt cookies issued by the other. The path is fixed in the
+# application code. Requires a ReadWriteMany-capable storage class.
+dataProtectionStorage:
+  size: "1Gi"
+  # null means "use the cluster default". Set a string to choose one.
+  storageClassName: null
+  mountPath: /root/.aspnet/DataProtection-Keys
+
+global:
+  # Image tag used when a component does not pin its own.
+  tag: "latest"
+
+  ingress:
+    enabled: true
+    className: "nginx"
+    certClusterIssuer: "ca-issuer"
+    tls: true
+
+  # Settings that both components need. Defined once, here.
+  config:
+    seqUrl: "http://seq:5341"
+    logLevel: "Information"
+    # Base URL of the Keycloak that holds the Dare-Control realm.
+    keycloakUrl: "http://keycloak.localtest.me:8085"
+    keycloakDemoMode: false
+    # Public URL of the Submission UI; Keycloak redirects browsers back here.
+    uiRedirectUrl: "http://submission.localtest.me"
+    suppressAntiforgery: false
+    sslCookies: false
+    httpsRedirect: false
+    rabbitmq:
+      host: "rabbitmq"
+      username: "rabbitmq"
+    vault:
+      url: "http://vault:8200"
+    proxy:
+      enabled: false
+      url: ""
+      bypass: "submission-api,seq"
+
+# --------------------------------------------------------------------
+# One block per component. Only the settings unique to that component.
+# --------------------------------------------------------------------
+
+api:
+  enabled: true
+  image:
+    repository: harbor.federated-analytics.ac.uk/5s-tes/submission-api
+    tag: ""
+    pullPolicy: IfNotPresent
+  replicas: 1
+  # Must match the port the ASP.NET app listens on inside the container.
+  containerPort: 8080
+  resources: {}
+  service:
+    type: ClusterIP
+  secretName: submission-api-secret
+  ingress:
+    enabled: true
+    host: "submission-api.localtest.me"
+  # Public URL of this API. It is embedded in the TRE onboarding data, so it
+  # must be reachable from remote agent/TRE hosts, not an in-cluster name.
+  publicUrl: "http://submission-api.localtest.me"
+  keycloak:
+    server: "keycloak.localtest.me"
+    protocol: "http"
+    validIssuer: "http://keycloak.localtest.me:8085/realms/Dare-Control"
+    autoTrustKeycloakCert: false
+    signedOutRedirectUri: "http://submission.localtest.me"
+    tokenRefreshSeconds: 300
+    adminUsername: "admin"
+  s3:
+    url: "http://rustfs-submission:9000"
+    adminConsole: "http://rustfs-submission:9001"
+  seedDemoData: false
+
+ui:
+  enabled: true
+  image:
+    repository: harbor.federated-analytics.ac.uk/5s-tes/submission-ui
+    tag: ""
+    pullPolicy: IfNotPresent
+  replicas: 1
+  containerPort: 8080
+  resources: {}
+  service:
+    type: ClusterIP
+  secretName: submission-ui-secret
+  ingress:
+    enabled: true
+    host: "submission.localtest.me"
+  apiAddress: "http://submission-api"
+  uiName: "Five Safes TES"
+  formIoUseInternal: true
+  frontend:
+    queryImageSql: "harbor.federated-analytics.ac.uk/5s-tes-analysis-tools/5s-tes-analysis-tools-tre-sqlpg:1.0.0"
+    # Browser-facing URL of the S3 console.
+    s3BaseUrl: "http://rustfs-submission.localtest.me"
+    s3BucketPath: "/rustfs/console/browser/?bucket="

--- a/charts/submission/values.yaml
+++ b/charts/submission/values.yaml
@@ -137,7 +137,6 @@ ui:
     host: "submission.localtest.me"
   apiAddress: "http://submission-api"
   uiName: "Five Safes TES"
-  formIoUseInternal: true
   frontend:
     queryImageSql: "harbor.federated-analytics.ac.uk/5s-tes-analysis-tools/5s-tes-analysis-tools-tre-sqlpg:1.0.0"
     # Browser-facing URL of the S3 console.

--- a/charts/submission/values.yaml
+++ b/charts/submission/values.yaml
@@ -52,6 +52,11 @@ dataProtectionStorage:
   storageClassName: null
   mountPath: /root/.aspnet/DataProtection-Keys
 
+# Prometheus pushgateway the components push metrics to.
+monitoring:
+  enabled: true
+  pushgatewayUrl: "http://prometheus-pushgateway.hiru-mgmt-monitoring.svc.cluster.local:9091/metrics"
+
 global:
   # Image tag used when a component does not pin its own.
   tag: "latest"


### PR DESCRIPTION
Standalone helm chart for the submission layer (api + ui), written per the Writing Helm Charts docs, plus the release workflow for it.

The env vars are lifted from the submission compose file in 5S-TES-deployment rather than appsettings.json, because compose sets things appsettings doesn't have (SuppressAntiforgery, FormIOSettings__UseInternal, the public SubmissionApiUrl, and so on).

api and ui share an RWX PVC for the ASP.NET data protection keys. The code writes them to /root/.aspnet/DataProtection-Keys, but the pods don't run as root and can't get into /root, so there's an emptyDir mounted over /root with the PVC at the key path inside it. Bit ugly, but it works without touching the code.

The chart doesn't create secrets, it expects them to already exist. Names and keys are in the chart README. The stack chart will create them from Vault later.


Probes: api uses the existing /health, ui just gets / since it has no health endpoint.


Also wires up prometheus metrics the same way serp-forms does it: prometheus-net MetricPusher in both apps, pushing to the pushgateway when PUSHGATEWAY_URL is set, with a monitoring block in the chart values.
