### PR TITLE
feat(helm): add standalone agent chart

### DIFF
--- a/.github/workflows/agent-chart.yaml
+++ b/.github/workflows/agent-chart.yaml
@@ -1,0 +1,40 @@
+name: Build Agent Helm Chart
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/agent-chart.yaml'
+      - 'charts/agent/**'
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/agent-chart.yaml'
+      - 'charts/agent/**'
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  agent-helm-chart:
+    uses: SwanseaUniversityMedical/workflows/.github/workflows/pr-and-release-chart.yaml@v4.0.0-charts
+    with:
+      job-name: agent-helm-chart
+      registry: ${{ vars.HARBOR_FEDA_REGISTRY }}
+      registry-user: ${{ vars.HARBOR_USER }}
+      registry-project: ${{ vars.HARBOR_PROJECT }}
+      registry-repo: agent
+      release-tag-format: 'Agent-Chart-${version}'
+      notation-cert: ${{ vars.NOTATION_CERT }}
+      chart: charts/agent
+      test-command: |
+        helm template $CHART --debug
+    secrets:
+      notation-key: ${{ secrets.NOTATION_KEY }}
+      registry-token: ${{ secrets.HARBOR_TOKEN }}

--- a/Agent/Agent.Api/Agent.Api.csproj
+++ b/Agent/Agent.Api/Agent.Api.csproj
@@ -21,6 +21,8 @@
 
   <ItemGroup>
 
+    <PackageReference Include="prometheus-net" Version="8.2.1" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="Hangfire.Dashboard.BasicAuthorization" Version="1.0.2" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.4" />
     <PackageReference Include="Hangfire" Version="1.8.6" />

--- a/Agent/Agent.Api/Program.cs
+++ b/Agent/Agent.Api/Program.cs
@@ -26,6 +26,7 @@ using Microsoft.FeatureManagement;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
+using Prometheus;
 using Serilog;
 using Serilog.Events;
 using VaultSharp;
@@ -267,6 +268,16 @@ builder.Services.AddCors(options =>
 });
 
 var app = builder.Build();
+
+if (Environment.GetEnvironmentVariable("PUSHGATEWAY_URL") != null)
+{
+    var pusher = new MetricPusher(new MetricPusherOptions
+    {
+        Endpoint = Environment.GetEnvironmentVariable("PUSHGATEWAY_URL"),
+        Job = Environment.GetEnvironmentVariable("PUSHGATEWAY_JOB")
+    });
+    pusher.Start();
+}
 app.UseForwardedHeaders(new ForwardedHeadersOptions
 {
     ForwardedHeaders = ForwardedHeaders.XForwardedProto

--- a/Agent/Agent.Api/Program.cs
+++ b/Agent/Agent.Api/Program.cs
@@ -49,6 +49,8 @@ if (configuration["SuppressAntiforgery"] != null && configuration["SuppressAntif
         .DisableAutomaticKeyGeneration();
 }
 
+builder.Services.AddHealthChecks();
+
 // Add services to the container.
 builder.Services.AddControllersWithViews().AddNewtonsoftJson(options =>
 {
@@ -338,6 +340,7 @@ app.UseRouting();
 app.UseCors(MyAllowSpecificOrigins);
 app.UseAuthentication();
 app.UseAuthorization();
+app.MapHealthChecks("/health");
 app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");

--- a/Agent/Agent.Web/Agent.Web.csproj
+++ b/Agent/Agent.Web/Agent.Web.csproj
@@ -20,6 +20,8 @@
 
   <ItemGroup>
 
+    <PackageReference Include="prometheus-net" Version="8.2.1" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="bootstrap" Version="5.3.2" />
     <PackageReference Include="IdentityModel" Version="6.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.3.0" />

--- a/Agent/Agent.Web/Program.cs
+++ b/Agent/Agent.Web/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.IdentityModel.Logging;
+using Prometheus;
 using Serilog;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
@@ -297,6 +298,17 @@ try
         "Program", treKeyCloakSettings.Authority, treKeyCloakSettings.MetadataAddress, treKeyCloakSettings.ClientId,
         treKeyCloakSettings.ValidAudiences);
     var app = builder.Build();
+
+    if (Environment.GetEnvironmentVariable("PUSHGATEWAY_URL") != null)
+    {
+        var pusher = new MetricPusher(new MetricPusherOptions
+        {
+            Endpoint = Environment.GetEnvironmentVariable("PUSHGATEWAY_URL"),
+            Job = Environment.GetEnvironmentVariable("PUSHGATEWAY_JOB")
+        });
+        pusher.Start();
+    }
+
     app.UseCors();
     app.UseForwardedHeaders();
 

--- a/Credentials/Credentials.Camunda/Credentials.Camunda.csproj
+++ b/Credentials/Credentials.Camunda/Credentials.Camunda.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="Hangfire" Version="1.8.21" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.22" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.22">

--- a/Credentials/Credentials.Camunda/Program.cs
+++ b/Credentials/Credentials.Camunda/Program.cs
@@ -1,3 +1,4 @@
+using Prometheus;
 using Serilog;
 using Credentials.Camunda.Extensions;
 using Credentials.Camunda.Settings;
@@ -40,6 +41,16 @@ Serilog.ILogger CreateSerilogLogger(IConfiguration configuration)
     .ReadFrom.Configuration(configuration)
     .CreateLogger();
 
+}
+
+if (Environment.GetEnvironmentVariable("PUSHGATEWAY_URL") != null)
+{
+    var pusher = new MetricPusher(new MetricPusherOptions
+    {
+        Endpoint = Environment.GetEnvironmentVariable("PUSHGATEWAY_URL"),
+        Job = Environment.GetEnvironmentVariable("PUSHGATEWAY_JOB")
+    });
+    pusher.Start();
 }
 
 await Host.CreateDefaultBuilder(args)

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: agent
+description: Standalone chart for the 5S TES Agent (TRE layer) API, UIs and Camunda credentials worker
+type: application
+version: 1.0.0
+appVersion: "3.1.1"

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -107,6 +107,13 @@ Set by `camundaWorker.secretName`.
 | `processModelsStorage.storageClassName` | Storage class for that claim. Must support ReadWriteMany. `null` uses the cluster default. | `null` |
 | `processModelsStorage.mountPath` | Where the models are mounted in the API and worker. Also sets `DmnPath__Path`. | `/app/ProcessModels` |
 
+### Monitoring
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `monitoring.enabled` | Push Prometheus metrics from the .NET components to a pushgateway. | `true` |
+| `monitoring.pushgatewayUrl` | Pushgateway address, including the `/metrics` path. | `http://prometheus-pushgateway.hiru-mgmt-monitoring.svc.cluster.local:9091/metrics` |
+
 ### Global parameters
 
 | **Name** | **Description** | **Value** |

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -1,0 +1,225 @@
+# agent
+
+Standalone chart for the 5S TES Agent (TRE layer).
+
+## What this chart deploys
+
+- `api` — Agent.Api, the TRE-side API. Also runs the Hangfire sync/scan/health jobs and consumes RabbitMQ messages.
+- `ui` — Agent.Web, the MVC frontend for the API.
+- `web` — agent-web, the Next.js frontend for the API.
+- `camunda-worker` — Credentials.Camunda, the Zeebe worker that issues ephemeral credentials.
+
+## What must already exist
+
+- The Secrets listed below, in the release namespace.
+- A ConfigMap holding the cluster CA bundle (see `trustClusterCa`).
+- A ReadWriteMany-capable storage class for the shared process models claim.
+
+## What this chart does not do
+
+It does not install PostgreSQL, Keycloak, RabbitMQ, Vault, Seq, Camunda,
+OpenLDAP, the S3 object stores, the Data Egress services or a TES executor
+(TESK/Funnel). It expects their addresses as values. The `agent-stack` chart
+installs the in-cluster ones and points this chart at them.
+
+## Secrets
+
+This chart does **not** create these. They must already exist in the
+namespace before the chart is installed. In our deployments the
+`agent-stack` chart creates them from Vault.
+
+### `agent-api-secret`
+
+Set by `api.secretName`.
+
+| **Key** | **Used for** | **Required** |
+|---|---|---|
+| `connectionString` | Full PostgreSQL connection string for the `DARE-Tre` database, including the password. Read into `ConnectionStrings__DefaultConnection`. Hangfire also stores its jobs here. | Yes |
+| `credentialsConnectionString` | Connection string for the `TRE_Credentials` database. | Yes |
+| `encryptionKey` | Base64 AES key (16, 24 or 32 bytes) for `EncryptionSettings__Key`. The API refuses to start without it. | Yes |
+| `treKeycloakClientSecret` | Client secret for the `Dare-TRE-UI` Keycloak client. | Yes |
+| `egressKeycloakClientSecret` | Client secret for the `Data-Egress-API` Keycloak client. | Yes |
+| `submissionKeycloakClientSecret` | Client secret for the `Dare-Control-API` Keycloak client on the Submission side. | Yes |
+| `rabbitPassword` | Password for the RabbitMQ user named in `global.config.rabbitmq.username`. | Yes |
+| `s3TreAccessKey` | Access key for the TRE object store at `api.s3Tre.url`. | Yes |
+| `s3TreSecretKey` | Secret key matching `s3TreAccessKey`. | Yes |
+| `vaultToken` | Token for the Vault at `global.config.vault.url`. The API also reloads configuration from Vault path `config`. | Yes |
+| `hangfirePassword` | Password for the Hangfire dashboard at `/hangfire`. Pairs with `api.hangfire.username`. | Yes |
+
+### `agent-ui-secret`
+
+Set by `ui.secretName`.
+
+| **Key** | **Used for** | **Required** |
+|---|---|---|
+| `keycloakClientSecret` | Client secret for the `Dare-TRE-UI` Keycloak client. | Yes |
+
+### `agent-web-secret`
+
+Set by `web.secretName`.
+
+| **Key** | **Used for** | **Required** |
+|---|---|---|
+| `keycloakClientSecret` | Client secret for the `Dare-TRE-UI` Keycloak client. | Yes |
+| `betterAuthSecret` | Session signing secret for better-auth. Any long random string; changing it signs everyone out. | Yes |
+
+### `agent-camunda-worker-secret`
+
+Set by `camundaWorker.secretName`.
+
+| **Key** | **Used for** | **Required** |
+|---|---|---|
+| `credentialsConnectionString` | Connection string for the `TRE_Credentials` database. | Yes |
+| `treDataConnectionString` | Connection string for the research data PostgreSQL that ephemeral credentials are granted against. A site-specific database, not the platform one. | Yes |
+| `ldapAdminPassword` | Admin password for the OpenLDAP at `camundaWorker.ldap.host`. | Yes |
+| `vaultToken` | Token for the Vault at `global.config.vault.url`, where issued credentials are stored. | Yes |
+
+## Parameters
+
+### Common parameters
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `nameOverride` | Replaces the chart name in object names. | `""` |
+| `fullnameOverride` | Replaces the full prefix on every object name. The stack chart sets this so service DNS names stay predictable. | `"agent"` |
+| `imagePullSecrets` | Secrets used to pull images from a private registry. | `[]` |
+| `serviceAccount.create` | Create a service account for the pods. | `true` |
+| `serviceAccount.annotations` | Annotations for the service account. | `{}` |
+| `serviceAccount.name` | Use an existing service account name instead. | `""` |
+| `podSecurityContext.fsGroup` | Group that owns mounted volumes, so the non-root app user can write the shared process models. | `1000` |
+| `securityContext.*` | Organisation security baseline (non-root, read-only filesystem, no capabilities). Do not weaken without a reason in the pull request. | see values |
+
+### Certificate trust
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `trustClusterCa.enabled` | Mount a cluster CA bundle over the container trust store. Turn off only on a cluster that has no such bundle. | `true` |
+| `trustClusterCa.configMapName` | ConfigMap holding the bundle. Provided by the cluster, not by this chart. | `overlay-castore` |
+| `trustClusterCa.key` | Key inside that ConfigMap. Also used as the mount `subPath`. | `ca-certificates.crt` |
+| `trustClusterCa.mountPath` | File replaced inside the container. Correct for Debian, Ubuntu and Alpine images. Also handed to Node via `NODE_EXTRA_CA_CERTS` in the `web` component. | `/etc/ssl/certs/ca-certificates.crt` |
+
+### Storage
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `persistentVolumeLabels` | Labels put on every PersistentVolumeClaim, for the cluster backup tool. Set `{}` for none. | `hiru.io/backup: "enabled"` |
+| `processModelsStorage.size` | Size of the shared DMN process models claim. | `1Gi` |
+| `processModelsStorage.storageClassName` | Storage class for that claim. Must support ReadWriteMany. `null` uses the cluster default. | `null` |
+| `processModelsStorage.mountPath` | Where the models are mounted in the API and worker. Also sets `DmnPath__Path`. | `/app/ProcessModels` |
+
+### Global parameters
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `global.tag` | Image tag used by any component that does not pin its own. | `latest` |
+| `global.ingress.enabled` | Master switch for every Ingress in the chart. | `true` |
+| `global.ingress.className` | Ingress controller class. | `nginx` |
+| `global.ingress.certClusterIssuer` | cert-manager ClusterIssuer that issues the TLS certificates. | `ca-issuer` |
+| `global.ingress.tls` | Render the TLS blocks. Turn off for local clusters with no issuer. | `true` |
+| `global.config.seqUrl` | Address of the Seq instance every component logs to. | `http://seq:5341` |
+| `global.config.logLevel` | Serilog minimum level for every component. | `Information` |
+| `global.config.treKeycloakUrl` | Base URL of the Keycloak holding the `Dare-TRE` and `Data-Egress` realms. Wrong value means nobody can log in. | `http://keycloak.localtest.me:8085` |
+| `global.config.submissionKeycloakUrl` | Base URL of the Keycloak holding the `Dare-Control` realm, on the Submission side. | `http://keycloak.localtest.me:8085` |
+| `global.config.keycloakDemoMode` | Keycloak demo mode flag. Keep off outside demos. | `false` |
+| `global.config.treApiPublicUrl` | Public URL of the agent API. The UIs and onboarding data embed it; must match the API ingress host. | `http://agent-api.localtest.me` |
+| `global.config.rabbitmq.host` | RabbitMQ host. Password comes from the API secret. | `rabbitmq` |
+| `global.config.rabbitmq.username` | RabbitMQ username. | `rabbitmq` |
+| `global.config.vault.url` | Address of the Vault used for credentials and live configuration. | `http://vault:8200` |
+| `global.config.zeebeGatewayAddress` | Zeebe gRPC gateway of the Camunda the API and worker connect to. | `orchestration:26500` |
+| `global.config.proxy.enabled` | Route Keycloak HTTP calls through a proxy. | `false` |
+| `global.config.proxy.url` | Proxy address, when enabled. | `""` |
+| `global.config.proxy.bypass` | Comma-separated hosts that skip the proxy. | `agent-api,seq` |
+
+### API parameters
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `api.enabled` | Deploy the API component. | `true` |
+| `api.image.repository` | Image for the API. | `harbor.federated-analytics.ac.uk/5s-tes/agent-api` |
+| `api.image.tag` | Image tag. Falls back to `global.tag` when empty. | `""` |
+| `api.image.pullPolicy` | Image pull policy. | `IfNotPresent` |
+| `api.replicas` | Number of copies. Keep at 1: the recurring jobs and the shared claim are not written for more. | `1` |
+| `api.containerPort` | Port the ASP.NET app listens on. Describes the app; it does not change it. | `8080` |
+| `api.resources` | CPU and memory requests/limits. | `{}` |
+| `api.service.type` | Service type. | `ClusterIP` |
+| `api.secretName` | Name of the Kubernetes Secret holding the API secrets. See **Secrets**. | `agent-api-secret` |
+| `api.ingress.enabled` | Create an Ingress for the API. | `true` |
+| `api.ingress.host` | Hostname for that Ingress. | `agent-api.localtest.me` |
+| `api.submissionApiUrl` | Address of the remote Submission API this TRE serves. External URL unless both layers share a cluster. | `http://submission-api.localtest.me` |
+| `api.treName` | Name this TRE registers with the Submission layer under. | `SAIL` |
+| `api.egress.apiAddress` | Address of the Data Egress API. | `http://egress-api` |
+| `api.egress.uiRedirectUrl` | Public URL of the Egress UI, for token-expiry redirects. | `http://egress.localtest.me` |
+| `api.tes.useTesk` | Submit tasks to a TES executor. Keep true in real deployments. | `true` |
+| `api.tes.apiUrl` | TES task endpoint (TESK or Funnel). Tasks go nowhere if this is wrong. | `http://tesk.localtest.me/v1/tasks` |
+| `api.tes.outputBucketPrefix` | Prefix put on output bucket paths handed to the executor. | `s3://` |
+| `api.jobs.syncSchedule` | Minutes between project/membership syncs. | `10` |
+| `api.jobs.scanSchedule` | Minutes between submission scans. | `10` |
+| `api.jobs.healthCheckSchedule` | Minutes between health check runs. | `1` |
+| `api.jobs.daysBeforeHealthLogDeletion` | Days health check rows are kept. | `30` |
+| `api.hangfire.enableExternal` | Expose the Hangfire dashboard at `/hangfire`. | `true` |
+| `api.hangfire.username` | Hangfire dashboard username. Password comes from the API secret. | `admin` |
+| `api.s3Tre.url` | S3 API of the TRE object store. | `http://rustfs-tre:9002` |
+| `api.s3Tre.adminConsole` | Console of that store. | `http://rustfs-tre:9003` |
+| `api.s3Sub.url` | S3 API of the Submission layer's object store; external in a split deployment. | `http://rustfs-submission.localtest.me` |
+| `api.credentialWebhooks.start` | Camunda connectors inbound webhook that starts credential issue. | `http://connectors:8080/inbound/StartCredentials` |
+| `api.credentialWebhooks.revoke` | Webhook that revokes credentials. | `http://connectors:8080/inbound/RevokeCredentials` |
+| `api.features.seedDemoData` | Seed demo data on start. Demos only. | `false` |
+| `api.features.ephemeralCredentials` | Issue ephemeral database credentials through Camunda. | `true` |
+| `api.onboardingConfigImported` | Marks the TRE onboarding configuration as already imported. | `false` |
+
+### UI parameters
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `ui.enabled` | Deploy the MVC UI component. | `true` |
+| `ui.image.repository` | Image for the UI. | `harbor.federated-analytics.ac.uk/5s-tes/agent-ui` |
+| `ui.image.tag` | Image tag. Falls back to `global.tag` when empty. | `""` |
+| `ui.image.pullPolicy` | Image pull policy. | `IfNotPresent` |
+| `ui.replicas` | Number of copies. | `1` |
+| `ui.containerPort` | Port the ASP.NET app listens on. | `8080` |
+| `ui.resources` | CPU and memory requests/limits. | `{}` |
+| `ui.service.type` | Service type. | `ClusterIP` |
+| `ui.secretName` | Name of the Kubernetes Secret holding the UI secrets. See **Secrets**. | `agent-ui-secret` |
+| `ui.ingress.enabled` | Create an Ingress for the UI. | `true` |
+| `ui.ingress.host` | Hostname for that Ingress. | `agent.localtest.me` |
+| `ui.apiAddress` | Address the UI calls the API on. The in-chart service name works unless the API is elsewhere. | `http://agent-api` |
+| `ui.uiName` | Product name shown in the UI. | `Five Safes TES` |
+| `ui.sslCookies` | Mark auth cookies secure. Needs HTTPS end to end. | `false` |
+| `ui.httpsRedirect` | Redirect HTTP to HTTPS inside the app. Usually off behind an ingress that already does this. | `false` |
+
+### Web parameters
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `web.enabled` | Deploy the Next.js web component. | `true` |
+| `web.image.repository` | Image for the web frontend. | `harbor.federated-analytics.ac.uk/5s-tes/agent-web` |
+| `web.image.tag` | Image tag. Falls back to `global.tag` when empty. | `""` |
+| `web.image.pullPolicy` | Image pull policy. | `IfNotPresent` |
+| `web.replicas` | Number of copies. Keep at 1 unless the better-auth session store is external. | `1` |
+| `web.containerPort` | Port the Node server listens on. | `3000` |
+| `web.resources` | CPU and memory requests/limits. | `{}` |
+| `web.service.type` | Service type. | `ClusterIP` |
+| `web.secretName` | Name of the Kubernetes Secret holding the web secrets. See **Secrets**. | `agent-web-secret` |
+| `web.ingress.enabled` | Create an Ingress for the web frontend. | `true` |
+| `web.ingress.host` | Hostname for that Ingress. Must match `web.publicUrl`. | `agent-web.localtest.me` |
+| `web.apiAddress` | Address the web frontend calls the API on. | `http://agent-api` |
+| `web.publicUrl` | Public URL of this frontend; better-auth builds login callbacks from it. | `http://agent-web.localtest.me` |
+| `web.helpdeskUrl` | Helpdesk link shown to users. | `https://ukserp.atlassian.net/servicedesk/customer/portal/3` |
+
+### Camunda worker parameters
+
+| **Name** | **Description** | **Value** |
+|---|---|---|
+| `camundaWorker.enabled` | Deploy the credentials worker. | `true` |
+| `camundaWorker.image.repository` | Image for the worker. | `harbor.federated-analytics.ac.uk/5s-tes/credentials-camunda` |
+| `camundaWorker.image.tag` | Image tag. Falls back to `global.tag` when empty. | `""` |
+| `camundaWorker.image.pullPolicy` | Image pull policy. | `IfNotPresent` |
+| `camundaWorker.replicas` | Number of copies. Keep at 1: it shares the process models claim with the API. | `1` |
+| `camundaWorker.resources` | CPU and memory requests/limits. | `{}` |
+| `camundaWorker.secretName` | Name of the Kubernetes Secret holding the worker secrets. See **Secrets**. | `agent-camunda-worker-secret` |
+| `camundaWorker.ldap.host` | OpenLDAP host ephemeral accounts are created in. | `openldap` |
+| `camundaWorker.ldap.port` | LDAP port. | `389` |
+| `camundaWorker.ldap.adminDn` | Bind DN for the LDAP admin. Password comes from the worker secret. | `cn=admin,dc=camundaephemeral,dc=local` |
+| `camundaWorker.ldap.baseDn` | Base DN accounts are created under. | `dc=camundaephemeral,dc=local` |
+| `camundaWorker.ldap.userOu` | OU that holds the ephemeral users. | `ou=Users` |
+| `camundaWorker.ldap.useSsl` | Use LDAPS. | `false` |

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -118,7 +118,7 @@ Set by `camundaWorker.secretName`.
 
 | **Name** | **Description** | **Value** |
 |---|---|---|
-| `global.tag` | Image tag used by any component that does not pin its own. | `latest` |
+| `global.tag` | Image tag used by any component that does not pin its own. | `3.1.1` |
 | `global.ingress.enabled` | Master switch for every Ingress in the chart. | `true` |
 | `global.ingress.className` | Ingress controller class. | `nginx` |
 | `global.ingress.certClusterIssuer` | cert-manager ClusterIssuer that issues the TLS certificates. | `ca-issuer` |
@@ -148,7 +148,7 @@ Set by `camundaWorker.secretName`.
 | `api.image.pullPolicy` | Image pull policy. | `IfNotPresent` |
 | `api.replicas` | Number of copies. Keep at 1: the recurring jobs and the shared claim are not written for more. | `1` |
 | `api.containerPort` | Port the ASP.NET app listens on. Describes the app; it does not change it. | `8080` |
-| `api.resources` | CPU and memory requests/limits. | `{}` |
+| `api.resources` | Resource requests and limits. Defaults set modest requests and memory/storage limits. | see `values.yaml` |
 | `api.service.type` | Service type. | `ClusterIP` |
 | `api.secretName` | Name of the Kubernetes Secret holding the API secrets. See **Secrets**. | `agent-api-secret` |
 | `api.ingress.enabled` | Create an Ingress for the API. | `true` |
@@ -193,7 +193,7 @@ Set by `camundaWorker.secretName`.
 | `ui.image.pullPolicy` | Image pull policy. | `IfNotPresent` |
 | `ui.replicas` | Number of copies. | `1` |
 | `ui.containerPort` | Port the ASP.NET app listens on. | `8080` |
-| `ui.resources` | CPU and memory requests/limits. | `{}` |
+| `ui.resources` | Resource requests and limits. Defaults set modest requests and memory/storage limits. | see `values.yaml` |
 | `ui.service.type` | Service type. | `ClusterIP` |
 | `ui.secretName` | Name of the Kubernetes Secret holding the UI secrets. See **Secrets**. | `agent-ui-secret` |
 | `ui.ingress.enabled` | Create an Ingress for the UI. | `true` |
@@ -215,7 +215,7 @@ Set by `camundaWorker.secretName`.
 | `web.image.pullPolicy` | Image pull policy. | `IfNotPresent` |
 | `web.replicas` | Number of copies. Keep at 1 unless the better-auth session store is external. | `1` |
 | `web.containerPort` | Port the Node server listens on. | `3000` |
-| `web.resources` | CPU and memory requests/limits. | `{}` |
+| `web.resources` | Resource requests and limits. Defaults set modest requests and memory/storage limits. | see `values.yaml` |
 | `web.service.type` | Service type. | `ClusterIP` |
 | `web.secretName` | Name of the Kubernetes Secret holding the web secrets. See **Secrets**. | `agent-web-secret` |
 | `web.ingress.enabled` | Create an Ingress for the web frontend. | `true` |
@@ -234,7 +234,7 @@ Set by `camundaWorker.secretName`.
 | `camundaWorker.image.tag` | Image tag. Falls back to `global.tag` when empty. | `""` |
 | `camundaWorker.image.pullPolicy` | Image pull policy. | `IfNotPresent` |
 | `camundaWorker.replicas` | Number of copies. Keep at 1: it shares the process models claim with the API. | `1` |
-| `camundaWorker.resources` | CPU and memory requests/limits. | `{}` |
+| `camundaWorker.resources` | Resource requests and limits. Defaults set modest requests and memory/storage limits. | see `values.yaml` |
 | `camundaWorker.secretName` | Name of the Kubernetes Secret holding the worker secrets. See **Secrets**. | `agent-camunda-worker-secret` |
 | `camundaWorker.ldap.host` | OpenLDAP host ephemeral accounts are created in. | `openldap` |
 | `camundaWorker.ldap.port` | LDAP port. | `389` |

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -148,7 +148,6 @@ Set by `camundaWorker.secretName`.
 | `api.submissionApiUrl` | Address of the remote Submission API this TRE serves. External URL unless both layers share a cluster. | `http://submission-api.localtest.me` |
 | `api.treName` | Name this TRE registers with the Submission layer under. | `SAIL` |
 | `api.egress.apiAddress` | Address of the Data Egress API. | `http://egress-api` |
-| `api.egress.uiRedirectUrl` | Public URL of the Egress UI, for token-expiry redirects. | `http://egress.localtest.me` |
 | `api.tes.useTesk` | Submit tasks to a TES executor. Keep true in real deployments. | `true` |
 | `api.tes.apiUrl` | TES task endpoint (TESK or Funnel). Tasks go nowhere if this is wrong. | `http://tesk.localtest.me/v1/tasks` |
 | `api.tes.outputBucketPrefix` | Prefix put on output bucket paths handed to the executor. | `s3://` |

--- a/charts/agent/README.md
+++ b/charts/agent/README.md
@@ -37,13 +37,13 @@ Set by `api.secretName`.
 | `connectionString` | Full PostgreSQL connection string for the `DARE-Tre` database, including the password. Read into `ConnectionStrings__DefaultConnection`. Hangfire also stores its jobs here. | Yes |
 | `credentialsConnectionString` | Connection string for the `TRE_Credentials` database. | Yes |
 | `encryptionKey` | Base64 AES key (16, 24 or 32 bytes) for `EncryptionSettings__Key`. The API refuses to start without it. | Yes |
-| `treKeycloakClientSecret` | Client secret for the `Dare-TRE-UI` Keycloak client. | Yes |
-| `egressKeycloakClientSecret` | Client secret for the `Data-Egress-API` Keycloak client. | Yes |
-| `submissionKeycloakClientSecret` | Client secret for the `Dare-Control-API` Keycloak client on the Submission side. | Yes |
+| `treKeycloakClientSecret` | Client secret for the client named in `api.treKeycloak.clientId`. | Yes |
+| `egressKeycloakClientSecret` | Client secret for the client named in `api.egress.keycloak.clientId`. | Yes |
+| `submissionKeycloakClientSecret` | Client secret for the client named in `api.submissionKeycloak.clientId`. | Yes |
 | `rabbitPassword` | Password for the RabbitMQ user named in `global.config.rabbitmq.username`. | Yes |
 | `s3TreAccessKey` | Access key for the TRE object store at `api.s3Tre.url`. | Yes |
 | `s3TreSecretKey` | Secret key matching `s3TreAccessKey`. | Yes |
-| `vaultToken` | Token for the Vault at `global.config.vault.url`. The API also reloads configuration from Vault path `config`. | Yes |
+| `vaultToken` | Token for the Vault at `global.config.vault.url`. The API also reloads configuration from the path in `api.vaultConfigPath`. | Yes |
 | `hangfirePassword` | Password for the Hangfire dashboard at `/hangfire`. Pairs with `api.hangfire.username`. | Yes |
 
 ### `agent-ui-secret`
@@ -52,7 +52,7 @@ Set by `ui.secretName`.
 
 | **Key** | **Used for** | **Required** |
 |---|---|---|
-| `keycloakClientSecret` | Client secret for the `Dare-TRE-UI` Keycloak client. | Yes |
+| `keycloakClientSecret` | Client secret for the client named in `ui.keycloak.clientId`. | Yes |
 
 ### `agent-web-secret`
 
@@ -60,7 +60,7 @@ Set by `web.secretName`.
 
 | **Key** | **Used for** | **Required** |
 |---|---|---|
-| `keycloakClientSecret` | Client secret for the `Dare-TRE-UI` Keycloak client. | Yes |
+| `keycloakClientSecret` | Client secret for the client named in `web.keycloak.clientId`. | Yes |
 | `betterAuthSecret` | Session signing secret for better-auth. Any long random string; changing it signs everyone out. | Yes |
 
 ### `agent-camunda-worker-secret`
@@ -125,13 +125,14 @@ Set by `camundaWorker.secretName`.
 | `global.ingress.tls` | Render the TLS blocks. Turn off for local clusters with no issuer. | `true` |
 | `global.config.seqUrl` | Address of the Seq instance every component logs to. | `http://seq:5341` |
 | `global.config.logLevel` | Serilog minimum level for every component. | `Information` |
-| `global.config.treKeycloakUrl` | Base URL of the Keycloak holding the `Dare-TRE` and `Data-Egress` realms. Wrong value means nobody can log in. | `http://keycloak.localtest.me:8085` |
-| `global.config.submissionKeycloakUrl` | Base URL of the Keycloak holding the `Dare-Control` realm, on the Submission side. | `http://keycloak.localtest.me:8085` |
+| `global.config.treKeycloak.url` | Base URL of the Keycloak holding the TRE realm (and the egress realm). Wrong value means nobody can log in. | `http://keycloak.localtest.me:8085` |
+| `global.config.treKeycloak.realm` | Name of the TRE realm on that Keycloak. | `Dare-TRE` |
 | `global.config.keycloakDemoMode` | Keycloak demo mode flag. Keep off outside demos. | `false` |
 | `global.config.treApiPublicUrl` | Public URL of the agent API. The UIs and onboarding data embed it; must match the API ingress host. | `http://agent-api.localtest.me` |
 | `global.config.rabbitmq.host` | RabbitMQ host. Password comes from the API secret. | `rabbitmq` |
 | `global.config.rabbitmq.username` | RabbitMQ username. | `rabbitmq` |
 | `global.config.vault.url` | Address of the Vault used for credentials and live configuration. | `http://vault:8200` |
+| `global.config.vault.secretEngine` | Vault KV engine the API and worker read from. | `secret` |
 | `global.config.zeebeGatewayAddress` | Zeebe gRPC gateway of the Camunda the API and worker connect to. | `orchestration:26500` |
 | `global.config.proxy.enabled` | Route Keycloak HTTP calls through a proxy. | `false` |
 | `global.config.proxy.url` | Proxy address, when enabled. | `""` |
@@ -154,7 +155,16 @@ Set by `camundaWorker.secretName`.
 | `api.ingress.host` | Hostname for that Ingress. | `agent-api.localtest.me` |
 | `api.submissionApiUrl` | Address of the remote Submission API this TRE serves. External URL unless both layers share a cluster. | `http://submission-api.localtest.me` |
 | `api.treName` | Name this TRE registers with the Submission layer under. | `SAIL` |
+| `api.treKeycloak.clientId` | Keycloak client the API authenticates as in the TRE realm. | `Dare-TRE-UI` |
+| `api.treKeycloak.validAudiences` | Audiences accepted in TRE realm tokens. | `Dare-TRE-API,Dare-TRE-UI` |
+| `api.submissionKeycloak.url` | Base URL of the Keycloak holding the Submission (control) realm, on the Submission side. | `http://keycloak.localtest.me:8085` |
+| `api.submissionKeycloak.realm` | Name of that realm. | `Dare-Control` |
+| `api.submissionKeycloak.clientId` | Client the API authenticates as in that realm. | `Dare-Control-API` |
+| `api.submissionKeycloak.validAudiences` | Audiences accepted in tokens from that realm. | `Dare-Control-UI,Dare-Control-API,Dare-Control-Minio` |
+| `api.vaultConfigPath` | Vault path the API reloads live configuration from. | `config` |
 | `api.egress.apiAddress` | Address of the Data Egress API. | `http://egress-api` |
+| `api.egress.keycloak.realm` | Name of the egress realm on the TRE Keycloak. | `Data-Egress` |
+| `api.egress.keycloak.clientId` | Client the API authenticates as in the egress realm. | `Data-Egress-API` |
 | `api.tes.useTesk` | Submit tasks to a TES executor. Keep true in real deployments. | `true` |
 | `api.tes.apiUrl` | TES task endpoint (TESK or Funnel). Tasks go nowhere if this is wrong. | `http://tesk.localtest.me/v1/tasks` |
 | `api.tes.outputBucketPrefix` | Prefix put on output bucket paths handed to the executor. | `s3://` |
@@ -190,6 +200,8 @@ Set by `camundaWorker.secretName`.
 | `ui.ingress.host` | Hostname for that Ingress. | `agent.localtest.me` |
 | `ui.apiAddress` | Address the UI calls the API on. The in-chart service name works unless the API is elsewhere. | `http://agent-api` |
 | `ui.uiName` | Product name shown in the UI. | `Five Safes TES` |
+| `ui.keycloak.clientId` | Keycloak client the UI logs users in with. | `Dare-TRE-UI` |
+| `ui.keycloak.validAudiences` | Audiences accepted in tokens. | `Dare-TRE-API,Dare-TRE-UI` |
 | `ui.sslCookies` | Mark auth cookies secure. Needs HTTPS end to end. | `false` |
 | `ui.httpsRedirect` | Redirect HTTP to HTTPS inside the app. Usually off behind an ingress that already does this. | `false` |
 
@@ -211,6 +223,7 @@ Set by `camundaWorker.secretName`.
 | `web.apiAddress` | Address the web frontend calls the API on. | `http://agent-api` |
 | `web.publicUrl` | Public URL of this frontend; better-auth builds login callbacks from it. | `http://agent-web.localtest.me` |
 | `web.helpdeskUrl` | Helpdesk link shown to users. | `https://ukserp.atlassian.net/servicedesk/customer/portal/3` |
+| `web.keycloak.clientId` | Keycloak client the web frontend logs users in with. | `Dare-TRE-UI` |
 
 ### Camunda worker parameters
 

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -1,0 +1,61 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncated at 63 characters because Kubernetes name fields are limited to this.
+*/}}
+{{- define "agent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Chart name and version, used by the chart label.
+*/}}
+{{- define "agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "agent.labels" -}}
+helm.sh/chart: {{ include "agent.chart" . }}
+{{ include "agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service account name to use.
+*/}}
+{{- define "agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "agent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/agent/templates/api/deployment.yaml
+++ b/charts/agent/templates/api/deployment.yaml
@@ -68,6 +68,12 @@ spec:
               port: http
             initialDelaySeconds: 5
           env:
+            {{- if .Values.monitoring.enabled }}
+            - name: PUSHGATEWAY_URL
+              value: "{{ .Values.monitoring.pushgatewayUrl }}"
+            - name: PUSHGATEWAY_JOB
+              value: {{ .Release.Namespace }}-{{ include "agent.fullname" . }}-api
+            {{- end }}
             - name: Serilog__SeqServerUrl
               value: "{{ .Values.global.config.seqUrl }}"
             - name: Serilog__MinimumLevel__Default

--- a/charts/agent/templates/api/deployment.yaml
+++ b/charts/agent/templates/api/deployment.yaml
@@ -187,18 +187,12 @@ spec:
                   key: treKeycloakClientSecret
             - name: TreKeyCloakSettings__ValidAudiences
               value: "Dare-TRE-API,Dare-TRE-UI"
-            - name: TreKeyCloakSettings__UseRedirectURL
-              value: "false"
             - name: TreKeyCloakSettings__Proxy
               value: "{{ .Values.global.config.proxy.enabled }}"
             - name: TreKeyCloakSettings__ProxyAddresURL
               value: "{{ .Values.global.config.proxy.url }}"
             - name: TreKeyCloakSettings__BypassProxy
               value: "{{ .Values.global.config.proxy.bypass }}"
-            - name: DataEgressKeyCloakSettings__Authority
-              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Data-Egress/.well-known/openid-configuration"
-            - name: DataEgressKeyCloakSettings__MetadataAddress
-              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Data-Egress/.well-known/openid-configuration"
             - name: DataEgressKeyCloakSettings__BaseUrl
               value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Data-Egress"
             - name: DataEgressKeyCloakSettings__ClientId
@@ -208,20 +202,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.api.secretName }}
                   key: egressKeycloakClientSecret
-            - name: DataEgressKeyCloakSettings__ValidAudiences
-              value: "Data-Egress-UI,Data-Egress-API"
-            - name: DataEgressKeyCloakSettings__TokenExpiredAddress
-              value: "{{ .Values.api.egress.uiRedirectUrl }}/Account/LoginAfterTokenExpired"
-            - name: DataEgressKeyCloakSettings__RedirectURL
-              value: "{{ .Values.api.egress.uiRedirectUrl }}"
-            - name: DataEgressKeyCloakSettings__UseRedirectURL
-              value: "false"
             - name: DataEgressKeyCloakSettings__Proxy
               value: "{{ .Values.global.config.proxy.enabled }}"
             - name: DataEgressKeyCloakSettings__ProxyAddresURL
               value: "{{ .Values.global.config.proxy.url }}"
-            - name: DataEgressKeyCloakSettings__BypassProxy
-              value: "{{ .Values.global.config.proxy.bypass }}"
             - name: SubmissionKeyCloakSettings__Authority
               value: "{{ .Values.global.config.submissionKeycloakUrl }}/realms/Dare-Control/.well-known/openid-configuration"
             - name: SubmissionKeyCloakSettings__MetadataAddress
@@ -237,8 +221,6 @@ spec:
                   key: submissionKeycloakClientSecret
             - name: SubmissionKeyCloakSettings__ValidAudiences
               value: "Dare-Control-UI,Dare-Control-API,Dare-Control-Minio"
-            - name: SubmissionKeyCloakSettings__UseRedirectURL
-              value: "false"
             - name: SubmissionKeyCloakSettings__Proxy
               value: "{{ .Values.global.config.proxy.enabled }}"
             - name: SubmissionKeyCloakSettings__ProxyAddresURL

--- a/charts/agent/templates/api/deployment.yaml
+++ b/charts/agent/templates/api/deployment.yaml
@@ -1,0 +1,268 @@
+{{- if .Values.api.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent.fullname" . }}-api
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  replicas: {{ .Values.api.replicas }}
+  selector:
+    matchLabels:
+      {{- include "agent.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: api
+  template:
+    metadata:
+      labels:
+        {{- include "agent.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: api
+    spec:
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        {{- if .Values.trustClusterCa.enabled }}
+        - name: certs-overlay
+          configMap:
+            name: {{ .Values.trustClusterCa.configMapName }}
+            defaultMode: 420
+        {{- end }}
+        - name: process-models
+          persistentVolumeClaim:
+            claimName: {{ include "agent.fullname" . }}-process-models
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: api
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag | default .Values.global.tag }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          volumeMounts:
+            {{- if .Values.trustClusterCa.enabled }}
+            - name: certs-overlay
+              mountPath: {{ .Values.trustClusterCa.mountPath }}
+              subPath: {{ .Values.trustClusterCa.key }}
+            {{- end }}
+            - name: process-models
+              mountPath: {{ .Values.processModelsStorage.mountPath }}
+            - name: tmp
+              mountPath: /tmp
+          ports:
+            - name: http
+              containerPort: {{ .Values.api.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+          env:
+            - name: Serilog__SeqServerUrl
+              value: "{{ .Values.global.config.seqUrl }}"
+            - name: Serilog__MinimumLevel__Default
+              value: "{{ .Values.global.config.logLevel }}"
+            - name: Logging__LogLevel__Default
+              value: "{{ .Values.global.config.logLevel }}"
+            - name: KeycloakDemoMode
+              value: "{{ .Values.global.config.keycloakDemoMode }}"
+            - name: TreName
+              value: "{{ .Values.api.treName }}"
+            - name: Features__SeedDemoData
+              value: "{{ .Values.api.features.seedDemoData }}"
+            - name: Features__EphemeralCredentials
+              value: "{{ .Values.api.features.ephemeralCredentials }}"
+            - name: TreOnboardingConfig__IsConfigurationImported
+              value: "{{ .Values.api.onboardingConfigImported }}"
+            - name: ConnectionStrings__DefaultConnection
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: connectionString
+            - name: ConnectionStrings__CredentialsConnection
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: credentialsConnectionString
+            - name: EncryptionSettings__Key
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: encryptionKey
+            - name: RabbitMQ__HostAddress
+              value: "{{ .Values.global.config.rabbitmq.host }}"
+            - name: RabbitMQ__Username
+              value: "{{ .Values.global.config.rabbitmq.username }}"
+            - name: RabbitMQ__Password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: rabbitPassword
+            - name: VaultSettings__BaseUrl
+              value: "{{ .Values.global.config.vault.url }}"
+            - name: VaultSettings__Token
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: vaultToken
+            - name: VaultSettings__TimeoutSeconds
+              value: "30"
+            - name: VaultSettings__SecretEngine
+              value: "secret"
+            - name: VaultSettings__EnableRetry
+              value: "true"
+            - name: VaultSettings__MaxRetryAttempts
+              value: "3"
+            - name: VaultSettings__VaultConfigPath
+              value: "config"
+            - name: VaultSettings__VaultConfigReloadInterval
+              value: "10"
+            - name: ApiEndpoints__SubmissionApiUrl
+              value: "{{ .Values.api.submissionApiUrl }}"
+            - name: ApiEndpoints__EgressApiUrl
+              value: "{{ .Values.api.egress.apiAddress }}"
+            - name: ApiEndpoints__TreApiUrl
+              value: "{{ .Values.global.config.treApiPublicUrl }}"
+            - name: AgentSettings__UseTESK
+              value: "{{ .Values.api.tes.useTesk }}"
+            - name: AgentSettings__TESKAPIURL
+              value: "{{ .Values.api.tes.apiUrl }}"
+            - name: AgentSettings__TESKOutputBucketPrefix
+              value: "{{ .Values.api.tes.outputBucketPrefix }}"
+            - name: JobSettings__syncSchedule
+              value: "{{ .Values.api.jobs.syncSchedule }}"
+            - name: JobSettings__scanSchedule
+              value: "{{ .Values.api.jobs.scanSchedule }}"
+            - name: JobSettings__healthCheckSchedule
+              value: "{{ .Values.api.jobs.healthCheckSchedule }}"
+            - name: JobSettings__DaysBeforeHealthLogDeletion
+              value: "{{ .Values.api.jobs.daysBeforeHealthLogDeletion }}"
+            - name: Hangfire__EnableExternalHangfire
+              value: "{{ .Values.api.hangfire.enableExternal }}"
+            - name: Hangfire__Username
+              value: "{{ .Values.api.hangfire.username }}"
+            - name: Hangfire__Password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: hangfirePassword
+            - name: MinioTRESettings__Url
+              value: "{{ .Values.api.s3Tre.url }}"
+            - name: MinioTRESettings__AdminConsole
+              value: "{{ .Values.api.s3Tre.adminConsole }}"
+            - name: MinioTRESettings__AccessKey
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: s3TreAccessKey
+            - name: MinioTRESettings__SecretKey
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: s3TreSecretKey
+            - name: MinioSubSettings__Url
+              value: "{{ .Values.api.s3Sub.url }}"
+            - name: TreKeyCloakSettings__Authority
+              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE/.well-known/openid-configuration"
+            - name: TreKeyCloakSettings__MetadataAddress
+              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE/.well-known/openid-configuration"
+            - name: TreKeyCloakSettings__BaseUrl
+              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE"
+            - name: TreKeyCloakSettings__ClientId
+              value: "Dare-TRE-UI"
+            - name: TreKeyCloakSettings__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: treKeycloakClientSecret
+            - name: TreKeyCloakSettings__ValidAudiences
+              value: "Dare-TRE-API,Dare-TRE-UI"
+            - name: TreKeyCloakSettings__UseRedirectURL
+              value: "false"
+            - name: TreKeyCloakSettings__Proxy
+              value: "{{ .Values.global.config.proxy.enabled }}"
+            - name: TreKeyCloakSettings__ProxyAddresURL
+              value: "{{ .Values.global.config.proxy.url }}"
+            - name: TreKeyCloakSettings__BypassProxy
+              value: "{{ .Values.global.config.proxy.bypass }}"
+            - name: DataEgressKeyCloakSettings__Authority
+              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Data-Egress/.well-known/openid-configuration"
+            - name: DataEgressKeyCloakSettings__MetadataAddress
+              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Data-Egress/.well-known/openid-configuration"
+            - name: DataEgressKeyCloakSettings__BaseUrl
+              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Data-Egress"
+            - name: DataEgressKeyCloakSettings__ClientId
+              value: "Data-Egress-API"
+            - name: DataEgressKeyCloakSettings__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: egressKeycloakClientSecret
+            - name: DataEgressKeyCloakSettings__ValidAudiences
+              value: "Data-Egress-UI,Data-Egress-API"
+            - name: DataEgressKeyCloakSettings__TokenExpiredAddress
+              value: "{{ .Values.api.egress.uiRedirectUrl }}/Account/LoginAfterTokenExpired"
+            - name: DataEgressKeyCloakSettings__RedirectURL
+              value: "{{ .Values.api.egress.uiRedirectUrl }}"
+            - name: DataEgressKeyCloakSettings__UseRedirectURL
+              value: "false"
+            - name: DataEgressKeyCloakSettings__Proxy
+              value: "{{ .Values.global.config.proxy.enabled }}"
+            - name: DataEgressKeyCloakSettings__ProxyAddresURL
+              value: "{{ .Values.global.config.proxy.url }}"
+            - name: DataEgressKeyCloakSettings__BypassProxy
+              value: "{{ .Values.global.config.proxy.bypass }}"
+            - name: SubmissionKeyCloakSettings__Authority
+              value: "{{ .Values.global.config.submissionKeycloakUrl }}/realms/Dare-Control/.well-known/openid-configuration"
+            - name: SubmissionKeyCloakSettings__MetadataAddress
+              value: "{{ .Values.global.config.submissionKeycloakUrl }}/realms/Dare-Control/.well-known/openid-configuration"
+            - name: SubmissionKeyCloakSettings__BaseUrl
+              value: "{{ .Values.global.config.submissionKeycloakUrl }}/realms/Dare-Control"
+            - name: SubmissionKeyCloakSettings__ClientId
+              value: "Dare-Control-API"
+            - name: SubmissionKeyCloakSettings__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.api.secretName }}
+                  key: submissionKeycloakClientSecret
+            - name: SubmissionKeyCloakSettings__ValidAudiences
+              value: "Dare-Control-UI,Dare-Control-API,Dare-Control-Minio"
+            - name: SubmissionKeyCloakSettings__UseRedirectURL
+              value: "false"
+            - name: SubmissionKeyCloakSettings__Proxy
+              value: "{{ .Values.global.config.proxy.enabled }}"
+            - name: SubmissionKeyCloakSettings__ProxyAddresURL
+              value: "{{ .Values.global.config.proxy.url }}"
+            - name: SubmissionKeyCloakSettings__BypassProxy
+              value: "{{ .Values.global.config.proxy.bypass }}"
+            - name: CredentialAPISettings__StartWebhookUrl
+              value: "{{ .Values.api.credentialWebhooks.start }}"
+            - name: CredentialAPISettings__RevokeWebhookUrl
+              value: "{{ .Values.api.credentialWebhooks.revoke }}"
+            - name: DmnPath__Path
+              value: "{{ .Values.processModelsStorage.mountPath }}"
+            - name: ZeebeBootstrap__Client__GatewayAddress
+              value: "{{ .Values.global.config.zeebeGatewayAddress }}"
+            - name: ZeebeBootstrap__Worker__MaxJobsActive
+              value: "5"
+            - name: ZeebeBootstrap__Worker__TimeoutInMilliseconds
+              value: "5000"
+            - name: ZeebeBootstrap__Worker__PollIntervalInMilliseconds
+              value: "1000"
+            - name: ZeebeBootstrap__Worker__PollingTimeoutInMilliseconds
+              value: "5000"
+            - name: ZeebeBootstrap__Worker__RetryTimeoutInMilliseconds
+              value: "5000"
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+{{- end }}

--- a/charts/agent/templates/api/deployment.yaml
+++ b/charts/agent/templates/api/deployment.yaml
@@ -124,13 +124,13 @@ spec:
             - name: VaultSettings__TimeoutSeconds
               value: "30"
             - name: VaultSettings__SecretEngine
-              value: "secret"
+              value: "{{ .Values.global.config.vault.secretEngine }}"
             - name: VaultSettings__EnableRetry
               value: "true"
             - name: VaultSettings__MaxRetryAttempts
               value: "3"
             - name: VaultSettings__VaultConfigPath
-              value: "config"
+              value: "{{ .Values.api.vaultConfigPath }}"
             - name: VaultSettings__VaultConfigReloadInterval
               value: "10"
             - name: ApiEndpoints__SubmissionApiUrl
@@ -179,20 +179,20 @@ spec:
             - name: MinioSubSettings__Url
               value: "{{ .Values.api.s3Sub.url }}"
             - name: TreKeyCloakSettings__Authority
-              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE/.well-known/openid-configuration"
+              value: "{{ .Values.global.config.treKeycloak.url }}/realms/{{ .Values.global.config.treKeycloak.realm }}/.well-known/openid-configuration"
             - name: TreKeyCloakSettings__MetadataAddress
-              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE/.well-known/openid-configuration"
+              value: "{{ .Values.global.config.treKeycloak.url }}/realms/{{ .Values.global.config.treKeycloak.realm }}/.well-known/openid-configuration"
             - name: TreKeyCloakSettings__BaseUrl
-              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE"
+              value: "{{ .Values.global.config.treKeycloak.url }}/realms/{{ .Values.global.config.treKeycloak.realm }}"
             - name: TreKeyCloakSettings__ClientId
-              value: "Dare-TRE-UI"
+              value: "{{ .Values.api.treKeycloak.clientId }}"
             - name: TreKeyCloakSettings__ClientSecret
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.api.secretName }}
                   key: treKeycloakClientSecret
             - name: TreKeyCloakSettings__ValidAudiences
-              value: "Dare-TRE-API,Dare-TRE-UI"
+              value: "{{ .Values.api.treKeycloak.validAudiences }}"
             - name: TreKeyCloakSettings__Proxy
               value: "{{ .Values.global.config.proxy.enabled }}"
             - name: TreKeyCloakSettings__ProxyAddresURL
@@ -200,9 +200,9 @@ spec:
             - name: TreKeyCloakSettings__BypassProxy
               value: "{{ .Values.global.config.proxy.bypass }}"
             - name: DataEgressKeyCloakSettings__BaseUrl
-              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Data-Egress"
+              value: "{{ .Values.global.config.treKeycloak.url }}/realms/{{ .Values.api.egress.keycloak.realm }}"
             - name: DataEgressKeyCloakSettings__ClientId
-              value: "Data-Egress-API"
+              value: "{{ .Values.api.egress.keycloak.clientId }}"
             - name: DataEgressKeyCloakSettings__ClientSecret
               valueFrom:
                 secretKeyRef:
@@ -213,20 +213,20 @@ spec:
             - name: DataEgressKeyCloakSettings__ProxyAddresURL
               value: "{{ .Values.global.config.proxy.url }}"
             - name: SubmissionKeyCloakSettings__Authority
-              value: "{{ .Values.global.config.submissionKeycloakUrl }}/realms/Dare-Control/.well-known/openid-configuration"
+              value: "{{ .Values.api.submissionKeycloak.url }}/realms/{{ .Values.api.submissionKeycloak.realm }}/.well-known/openid-configuration"
             - name: SubmissionKeyCloakSettings__MetadataAddress
-              value: "{{ .Values.global.config.submissionKeycloakUrl }}/realms/Dare-Control/.well-known/openid-configuration"
+              value: "{{ .Values.api.submissionKeycloak.url }}/realms/{{ .Values.api.submissionKeycloak.realm }}/.well-known/openid-configuration"
             - name: SubmissionKeyCloakSettings__BaseUrl
-              value: "{{ .Values.global.config.submissionKeycloakUrl }}/realms/Dare-Control"
+              value: "{{ .Values.api.submissionKeycloak.url }}/realms/{{ .Values.api.submissionKeycloak.realm }}"
             - name: SubmissionKeyCloakSettings__ClientId
-              value: "Dare-Control-API"
+              value: "{{ .Values.api.submissionKeycloak.clientId }}"
             - name: SubmissionKeyCloakSettings__ClientSecret
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.api.secretName }}
                   key: submissionKeycloakClientSecret
             - name: SubmissionKeyCloakSettings__ValidAudiences
-              value: "Dare-Control-UI,Dare-Control-API,Dare-Control-Minio"
+              value: "{{ .Values.api.submissionKeycloak.validAudiences }}"
             - name: SubmissionKeyCloakSettings__Proxy
               value: "{{ .Values.global.config.proxy.enabled }}"
             - name: SubmissionKeyCloakSettings__ProxyAddresURL

--- a/charts/agent/templates/api/deployment.yaml
+++ b/charts/agent/templates/api/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: api
     spec:
       serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/agent/templates/api/ingress.yaml
+++ b/charts/agent/templates/api/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.api.enabled .Values.api.ingress.enabled .Values.global.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agent.fullname" . }}-api
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.global.ingress.certClusterIssuer }}
+    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+spec:
+  ingressClassName: {{ .Values.global.ingress.className }}
+  {{- if .Values.global.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.api.ingress.host }}
+      secretName: {{ include "agent.fullname" . }}-api-tls
+  {{- end }}
+  rules:
+    - host: {{ .Values.api.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "agent.fullname" . }}-api
+                port:
+                  number: 80
+{{- end }}

--- a/charts/agent/templates/api/service.yaml
+++ b/charts/agent/templates/api/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.api.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agent.fullname" . }}-api
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+spec:
+  type: {{ .Values.api.service.type }}
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "agent.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: api
+{{- end }}

--- a/charts/agent/templates/camunda-worker/deployment.yaml
+++ b/charts/agent/templates/camunda-worker/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: camunda-worker
     spec:
       serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/agent/templates/camunda-worker/deployment.yaml
+++ b/charts/agent/templates/camunda-worker/deployment.yaml
@@ -1,0 +1,121 @@
+{{- if .Values.camundaWorker.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent.fullname" . }}-camunda-worker
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: camunda-worker
+spec:
+  replicas: {{ .Values.camundaWorker.replicas }}
+  selector:
+    matchLabels:
+      {{- include "agent.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: camunda-worker
+  template:
+    metadata:
+      labels:
+        {{- include "agent.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: camunda-worker
+    spec:
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        {{- if .Values.trustClusterCa.enabled }}
+        - name: certs-overlay
+          configMap:
+            name: {{ .Values.trustClusterCa.configMapName }}
+            defaultMode: 420
+        {{- end }}
+        - name: process-models
+          persistentVolumeClaim:
+            claimName: {{ include "agent.fullname" . }}-process-models
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: camunda-worker
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.camundaWorker.image.repository }}:{{ .Values.camundaWorker.image.tag | default .Values.global.tag }}"
+          imagePullPolicy: {{ .Values.camundaWorker.image.pullPolicy }}
+          volumeMounts:
+            {{- if .Values.trustClusterCa.enabled }}
+            - name: certs-overlay
+              mountPath: {{ .Values.trustClusterCa.mountPath }}
+              subPath: {{ .Values.trustClusterCa.key }}
+            {{- end }}
+            - name: process-models
+              mountPath: {{ .Values.processModelsStorage.mountPath }}
+            - name: tmp
+              mountPath: /tmp
+          env:
+            - name: Serilog__SeqServerUrl
+              value: "{{ .Values.global.config.seqUrl }}"
+            - name: Serilog__MinimumLevel__Default
+              value: "{{ .Values.global.config.logLevel }}"
+            - name: Logging__LogLevel__Default
+              value: "{{ .Values.global.config.logLevel }}"
+            - name: DmnPath__Path
+              value: "{{ .Values.processModelsStorage.mountPath }}"
+            - name: ConnectionStrings__CredentialsConnection
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.camundaWorker.secretName }}
+                  key: credentialsConnectionString
+            - name: ConnectionStrings__TREPostgresConnection
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.camundaWorker.secretName }}
+                  key: treDataConnectionString
+            - name: VaultSettings__BaseUrl
+              value: "{{ .Values.global.config.vault.url }}"
+            - name: VaultSettings__Token
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.camundaWorker.secretName }}
+                  key: vaultToken
+            - name: VaultSettings__TimeoutSeconds
+              value: "30"
+            - name: VaultSettings__SecretEngine
+              value: "secret"
+            - name: VaultSettings__EnableRetry
+              value: "true"
+            - name: VaultSettings__MaxRetryAttempts
+              value: "3"
+            - name: LdapSettings__Host
+              value: "{{ .Values.camundaWorker.ldap.host }}"
+            - name: LdapSettings__Port
+              value: "{{ .Values.camundaWorker.ldap.port }}"
+            - name: LdapSettings__AdminDn
+              value: "{{ .Values.camundaWorker.ldap.adminDn }}"
+            - name: LdapSettings__AdminPassword
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.camundaWorker.secretName }}
+                  key: ldapAdminPassword
+            - name: LdapSettings__BaseDn
+              value: "{{ .Values.camundaWorker.ldap.baseDn }}"
+            - name: LdapSettings__UserOu
+              value: "{{ .Values.camundaWorker.ldap.userOu }}"
+            - name: LdapSettings__UseSSL
+              value: "{{ .Values.camundaWorker.ldap.useSsl }}"
+            - name: ZeebeBootstrap__Client__GatewayAddress
+              value: "{{ .Values.global.config.zeebeGatewayAddress }}"
+            - name: ZeebeBootstrap__Worker__MaxJobsActive
+              value: "5"
+            - name: ZeebeBootstrap__Worker__TimeoutInMilliseconds
+              value: "5000"
+            - name: ZeebeBootstrap__Worker__PollIntervalInMilliseconds
+              value: "1000"
+            - name: ZeebeBootstrap__Worker__PollingTimeoutInMilliseconds
+              value: "5000"
+            - name: ZeebeBootstrap__Worker__RetryTimeoutInMilliseconds
+              value: "5000"
+          resources:
+            {{- toYaml .Values.camundaWorker.resources | nindent 12 }}
+{{- end }}

--- a/charts/agent/templates/camunda-worker/deployment.yaml
+++ b/charts/agent/templates/camunda-worker/deployment.yaml
@@ -88,7 +88,7 @@ spec:
             - name: VaultSettings__TimeoutSeconds
               value: "30"
             - name: VaultSettings__SecretEngine
-              value: "secret"
+              value: "{{ .Values.global.config.vault.secretEngine }}"
             - name: VaultSettings__EnableRetry
               value: "true"
             - name: VaultSettings__MaxRetryAttempts

--- a/charts/agent/templates/camunda-worker/deployment.yaml
+++ b/charts/agent/templates/camunda-worker/deployment.yaml
@@ -54,6 +54,12 @@ spec:
             - name: tmp
               mountPath: /tmp
           env:
+            {{- if .Values.monitoring.enabled }}
+            - name: PUSHGATEWAY_URL
+              value: "{{ .Values.monitoring.pushgatewayUrl }}"
+            - name: PUSHGATEWAY_JOB
+              value: {{ .Release.Namespace }}-{{ include "agent.fullname" . }}-camunda-worker
+            {{- end }}
             - name: Serilog__SeqServerUrl
               value: "{{ .Values.global.config.seqUrl }}"
             - name: Serilog__MinimumLevel__Default

--- a/charts/agent/templates/pvc-process-models.yaml
+++ b/charts/agent/templates/pvc-process-models.yaml
@@ -1,0 +1,22 @@
+{{- if or .Values.api.enabled .Values.camundaWorker.enabled -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "agent.fullname" . }}-process-models
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+    {{- with .Values.persistentVolumeLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if typeIs "string" .Values.processModelsStorage.storageClassName }}
+  storageClassName: {{ .Values.processModelsStorage.storageClassName | quote }}
+  {{- end }}
+  # ReadWriteMany: the API and the Camunda worker pods both read and write
+  # the DMN process models.
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.processModelsStorage.size | quote }}
+{{- end }}

--- a/charts/agent/templates/serviceaccount.yaml
+++ b/charts/agent/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent.serviceAccountName" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/agent/templates/ui/deployment.yaml
+++ b/charts/agent/templates/ui/deployment.yaml
@@ -63,6 +63,12 @@ spec:
               port: http
             initialDelaySeconds: 5
           env:
+            {{- if .Values.monitoring.enabled }}
+            - name: PUSHGATEWAY_URL
+              value: "{{ .Values.monitoring.pushgatewayUrl }}"
+            - name: PUSHGATEWAY_JOB
+              value: {{ .Release.Namespace }}-{{ include "agent.fullname" . }}-ui
+            {{- end }}
             - name: UIName__Name
               value: "{{ .Values.ui.uiName }}"
             - name: Serilog__SeqServerUrl

--- a/charts/agent/templates/ui/deployment.yaml
+++ b/charts/agent/templates/ui/deployment.yaml
@@ -88,22 +88,22 @@ spec:
             - name: TreAPISettings__PublicApiBaseUrl
               value: "{{ .Values.global.config.treApiPublicUrl }}"
             - name: TreKeyCloakSettings__AccountManagementURL
-              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE/account"
+              value: "{{ .Values.global.config.treKeycloak.url }}/realms/{{ .Values.global.config.treKeycloak.realm }}/account"
             - name: TreKeyCloakSettings__Authority
-              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE/.well-known/openid-configuration"
+              value: "{{ .Values.global.config.treKeycloak.url }}/realms/{{ .Values.global.config.treKeycloak.realm }}/.well-known/openid-configuration"
             - name: TreKeyCloakSettings__MetadataAddress
-              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE/.well-known/openid-configuration"
+              value: "{{ .Values.global.config.treKeycloak.url }}/realms/{{ .Values.global.config.treKeycloak.realm }}/.well-known/openid-configuration"
             - name: TreKeyCloakSettings__BaseUrl
-              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE"
+              value: "{{ .Values.global.config.treKeycloak.url }}/realms/{{ .Values.global.config.treKeycloak.realm }}"
             - name: TreKeyCloakSettings__ClientId
-              value: "Dare-TRE-UI"
+              value: "{{ .Values.ui.keycloak.clientId }}"
             - name: TreKeyCloakSettings__ClientSecret
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.ui.secretName }}
                   key: keycloakClientSecret
             - name: TreKeyCloakSettings__ValidAudiences
-              value: "Dare-TRE-API,Dare-TRE-UI"
+              value: "{{ .Values.ui.keycloak.validAudiences }}"
             - name: TreKeyCloakSettings__Proxy
               value: "{{ .Values.global.config.proxy.enabled }}"
             - name: TreKeyCloakSettings__ProxyAddresURL

--- a/charts/agent/templates/ui/deployment.yaml
+++ b/charts/agent/templates/ui/deployment.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.ui.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent.fullname" . }}-ui
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+spec:
+  replicas: {{ .Values.ui.replicas }}
+  selector:
+    matchLabels:
+      {{- include "agent.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: ui
+  template:
+    metadata:
+      labels:
+        {{- include "agent.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: ui
+    spec:
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        {{- if .Values.trustClusterCa.enabled }}
+        - name: certs-overlay
+          configMap:
+            name: {{ .Values.trustClusterCa.configMapName }}
+            defaultMode: 420
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: ui
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag | default .Values.global.tag }}"
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          volumeMounts:
+            {{- if .Values.trustClusterCa.enabled }}
+            - name: certs-overlay
+              mountPath: {{ .Values.trustClusterCa.mountPath }}
+              subPath: {{ .Values.trustClusterCa.key }}
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+          ports:
+            - name: http
+              containerPort: {{ .Values.ui.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+          env:
+            - name: UIName__Name
+              value: "{{ .Values.ui.uiName }}"
+            - name: Serilog__SeqServerUrl
+              value: "{{ .Values.global.config.seqUrl }}"
+            - name: Serilog__MinimumLevel__Default
+              value: "{{ .Values.global.config.logLevel }}"
+            - name: Logging__LogLevel__Default
+              value: "{{ .Values.global.config.logLevel }}"
+            - name: KeycloakDemoMode
+              value: "{{ .Values.global.config.keycloakDemoMode }}"
+            - name: sslcookies
+              value: "{{ .Values.ui.sslCookies }}"
+            - name: httpsRedirect
+              value: "{{ .Values.ui.httpsRedirect }}"
+            - name: TreAPISettings__InternalApiBaseUrl
+              value: "{{ .Values.ui.apiAddress }}"
+            - name: TreAPISettings__PublicApiBaseUrl
+              value: "{{ .Values.global.config.treApiPublicUrl }}"
+            - name: TreKeyCloakSettings__AccountManagementURL
+              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE/account"
+            - name: TreKeyCloakSettings__Authority
+              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE/.well-known/openid-configuration"
+            - name: TreKeyCloakSettings__MetadataAddress
+              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE/.well-known/openid-configuration"
+            - name: TreKeyCloakSettings__BaseUrl
+              value: "{{ .Values.global.config.treKeycloakUrl }}/realms/Dare-TRE"
+            - name: TreKeyCloakSettings__ClientId
+              value: "Dare-TRE-UI"
+            - name: TreKeyCloakSettings__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ui.secretName }}
+                  key: keycloakClientSecret
+            - name: TreKeyCloakSettings__ValidAudiences
+              value: "Dare-TRE-API,Dare-TRE-UI"
+            - name: TreKeyCloakSettings__UseRedirectURL
+              value: "false"
+            - name: TreKeyCloakSettings__Proxy
+              value: "{{ .Values.global.config.proxy.enabled }}"
+            - name: TreKeyCloakSettings__ProxyAddresURL
+              value: "{{ .Values.global.config.proxy.url }}"
+            - name: TreKeyCloakSettings__BypassProxy
+              value: "{{ .Values.global.config.proxy.bypass }}"
+          resources:
+            {{- toYaml .Values.ui.resources | nindent 12 }}
+{{- end }}

--- a/charts/agent/templates/ui/deployment.yaml
+++ b/charts/agent/templates/ui/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: ui
     spec:
       serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/agent/templates/ui/deployment.yaml
+++ b/charts/agent/templates/ui/deployment.yaml
@@ -98,8 +98,6 @@ spec:
                   key: keycloakClientSecret
             - name: TreKeyCloakSettings__ValidAudiences
               value: "Dare-TRE-API,Dare-TRE-UI"
-            - name: TreKeyCloakSettings__UseRedirectURL
-              value: "false"
             - name: TreKeyCloakSettings__Proxy
               value: "{{ .Values.global.config.proxy.enabled }}"
             - name: TreKeyCloakSettings__ProxyAddresURL

--- a/charts/agent/templates/ui/ingress.yaml
+++ b/charts/agent/templates/ui/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.ui.enabled .Values.ui.ingress.enabled .Values.global.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agent.fullname" . }}-ui
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.global.ingress.certClusterIssuer }}
+    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+spec:
+  ingressClassName: {{ .Values.global.ingress.className }}
+  {{- if .Values.global.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.ui.ingress.host }}
+      secretName: {{ include "agent.fullname" . }}-ui-tls
+  {{- end }}
+  rules:
+    - host: {{ .Values.ui.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "agent.fullname" . }}-ui
+                port:
+                  number: 80
+{{- end }}

--- a/charts/agent/templates/ui/service.yaml
+++ b/charts/agent/templates/ui/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.ui.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agent.fullname" . }}-ui
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+spec:
+  type: {{ .Values.ui.service.type }}
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "agent.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ui
+{{- end }}

--- a/charts/agent/templates/web/deployment.yaml
+++ b/charts/agent/templates/web/deployment.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: web
     spec:
       serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/agent/templates/web/deployment.yaml
+++ b/charts/agent/templates/web/deployment.yaml
@@ -1,0 +1,102 @@
+{{- if .Values.web.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "agent.fullname" . }}-web
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  replicas: {{ .Values.web.replicas }}
+  selector:
+    matchLabels:
+      {{- include "agent.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: web
+  template:
+    metadata:
+      labels:
+        {{- include "agent.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: web
+    spec:
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        {{- if .Values.trustClusterCa.enabled }}
+        - name: certs-overlay
+          configMap:
+            name: {{ .Values.trustClusterCa.configMapName }}
+            defaultMode: 420
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+        - name: next-cache
+          emptyDir: {}
+      containers:
+        - name: web
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag | default .Values.global.tag }}"
+          imagePullPolicy: {{ .Values.web.image.pullPolicy }}
+          volumeMounts:
+            {{- if .Values.trustClusterCa.enabled }}
+            - name: certs-overlay
+              mountPath: {{ .Values.trustClusterCa.mountPath }}
+              subPath: {{ .Values.trustClusterCa.key }}
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+            - name: next-cache
+              mountPath: /app/.next/cache
+          ports:
+            - name: http
+              containerPort: {{ .Values.web.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+          env:
+            {{- if .Values.trustClusterCa.enabled }}
+            # Node does not read the system trust store; point it at the
+            # mounted bundle.
+            - name: NODE_EXTRA_CA_CERTS
+              value: "{{ .Values.trustClusterCa.mountPath }}"
+            {{- end }}
+            - name: AGENT_API_URL
+              value: "{{ .Values.web.apiAddress }}"
+            - name: BETTER_AUTH_URL
+              value: "{{ .Values.web.publicUrl }}"
+            - name: BETTER_AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.web.secretName }}
+                  key: betterAuthSecret
+            - name: KEYCLOAK_URL
+              value: "{{ .Values.global.config.treKeycloakUrl }}"
+            - name: KEYCLOAK_CLIENT_ID
+              value: "Dare-TRE-UI"
+            - name: KEYCLOAK_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.web.secretName }}
+                  key: keycloakClientSecret
+            - name: NEXT_PUBLIC_KEYCLOAK_URL
+              value: "{{ .Values.global.config.treKeycloakUrl }}"
+            - name: NEXT_PUBLIC_KEYCLOAK_REALM
+              value: "Dare-TRE"
+            - name: NEXT_PUBLIC_HELPDESK_URL
+              value: "{{ .Values.web.helpdeskUrl }}"
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+{{- end }}

--- a/charts/agent/templates/web/deployment.yaml
+++ b/charts/agent/templates/web/deployment.yaml
@@ -83,18 +83,18 @@ spec:
                   name: {{ .Values.web.secretName }}
                   key: betterAuthSecret
             - name: KEYCLOAK_URL
-              value: "{{ .Values.global.config.treKeycloakUrl }}"
+              value: "{{ .Values.global.config.treKeycloak.url }}"
             - name: KEYCLOAK_CLIENT_ID
-              value: "Dare-TRE-UI"
+              value: "{{ .Values.web.keycloak.clientId }}"
             - name: KEYCLOAK_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.web.secretName }}
                   key: keycloakClientSecret
             - name: NEXT_PUBLIC_KEYCLOAK_URL
-              value: "{{ .Values.global.config.treKeycloakUrl }}"
+              value: "{{ .Values.global.config.treKeycloak.url }}"
             - name: NEXT_PUBLIC_KEYCLOAK_REALM
-              value: "Dare-TRE"
+              value: "{{ .Values.global.config.treKeycloak.realm }}"
             - name: NEXT_PUBLIC_HELPDESK_URL
               value: "{{ .Values.web.helpdeskUrl }}"
           resources:

--- a/charts/agent/templates/web/ingress.yaml
+++ b/charts/agent/templates/web/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.web.enabled .Values.web.ingress.enabled .Values.global.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agent.fullname" . }}-web
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.global.ingress.certClusterIssuer }}
+    nginx.ingress.kubernetes.io/backend-protocol: HTTP
+spec:
+  ingressClassName: {{ .Values.global.ingress.className }}
+  {{- if .Values.global.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ .Values.web.ingress.host }}
+      secretName: {{ include "agent.fullname" . }}-web-tls
+  {{- end }}
+  rules:
+    - host: {{ .Values.web.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "agent.fullname" . }}-web
+                port:
+                  number: 80
+{{- end }}

--- a/charts/agent/templates/web/service.yaml
+++ b/charts/agent/templates/web/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.web.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agent.fullname" . }}-web
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+spec:
+  type: {{ .Values.web.service.type }}
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "agent.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+{{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -71,11 +71,10 @@ global:
   config:
     seqUrl: "http://seq:5341"
     logLevel: "Information"
-    # Base URL of the Keycloak that holds the Dare-TRE and Data-Egress realms.
-    treKeycloakUrl: "http://keycloak.localtest.me:8085"
-    # Base URL of the Keycloak that holds the Dare-Control realm, on the
-    # Submission side. Often a different Keycloak from the TRE one.
-    submissionKeycloakUrl: "http://keycloak.localtest.me:8085"
+    # Keycloak that holds the TRE realm (and the egress realm).
+    treKeycloak:
+      url: "http://keycloak.localtest.me:8085"
+      realm: "Dare-TRE"
     keycloakDemoMode: false
     # Public URL of the agent API; used in onboarding data and by the UIs.
     treApiPublicUrl: "http://agent-api.localtest.me"
@@ -84,6 +83,7 @@ global:
       username: "rabbitmq"
     vault:
       url: "http://vault:8200"
+      secretEngine: "secret"
     # Zeebe gRPC gateway of the Camunda the API and worker connect to.
     zeebeGatewayAddress: "orchestration:26500"
     proxy:
@@ -115,8 +115,22 @@ api:
   # not an in-cluster name, unless both layers share a cluster.
   submissionApiUrl: "http://submission-api.localtest.me"
   treName: "SAIL"
+  treKeycloak:
+    clientId: "Dare-TRE-UI"
+    validAudiences: "Dare-TRE-API,Dare-TRE-UI"
+  # Keycloak that holds the Submission (control) realm, on the Submission
+  # side. Often a different Keycloak from the TRE one.
+  submissionKeycloak:
+    url: "http://keycloak.localtest.me:8085"
+    realm: "Dare-Control"
+    clientId: "Dare-Control-API"
+    validAudiences: "Dare-Control-UI,Dare-Control-API,Dare-Control-Minio"
+  vaultConfigPath: "config"
   egress:
     apiAddress: "http://egress-api"
+    keycloak:
+      realm: "Data-Egress"
+      clientId: "Data-Egress-API"
   tes:
     useTesk: true
     apiUrl: "http://tesk.localtest.me/v1/tasks"
@@ -161,6 +175,9 @@ ui:
     host: "agent.localtest.me"
   apiAddress: "http://agent-api"
   uiName: "Five Safes TES"
+  keycloak:
+    clientId: "Dare-TRE-UI"
+    validAudiences: "Dare-TRE-API,Dare-TRE-UI"
   sslCookies: false
   httpsRedirect: false
 
@@ -182,6 +199,8 @@ web:
   apiAddress: "http://agent-api"
   # Public URL of this UI itself; better-auth builds callbacks from it.
   publicUrl: "http://agent-web.localtest.me"
+  keycloak:
+    clientId: "Dare-TRE-UI"
   helpdeskUrl: "https://ukserp.atlassian.net/servicedesk/customer/portal/3"
 
 camundaWorker:

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -52,6 +52,11 @@ processModelsStorage:
   storageClassName: null
   mountPath: /app/ProcessModels
 
+# Prometheus pushgateway the .NET components push metrics to.
+monitoring:
+  enabled: true
+  pushgatewayUrl: "http://prometheus-pushgateway.hiru-mgmt-monitoring.svc.cluster.local:9091/metrics"
+
 global:
   # Image tag used when a component does not pin its own.
   tag: "latest"

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -112,8 +112,6 @@ api:
   treName: "SAIL"
   egress:
     apiAddress: "http://egress-api"
-    # Public URL of the Egress UI, used in token-expiry redirects.
-    uiRedirectUrl: "http://egress.localtest.me"
   tes:
     useTesk: true
     apiUrl: "http://tesk.localtest.me/v1/tasks"

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -1,0 +1,199 @@
+# Default values for the standalone `agent` chart.
+# The agent-stack chart overrides these through an ArgoCD `Application`.
+# The defaults below are local development settings, so that
+# `helm template ./charts/agent` renders without any extra input.
+
+nameOverride: ""
+# The stack sets this so that service DNS names stay `agent-<component>`.
+fullnameOverride: "agent"
+
+imagePullSecrets: []
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podSecurityContext:
+  fsGroup: 1000
+
+# Organisation security baseline. Do not weaken this without a reason
+# written in the pull request.
+securityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+# Mounts a cluster certificate bundle over every container's trust store, so
+# the apps trust internal HTTPS addresses. The ConfigMap is provided by the
+# cluster, not created by this chart.
+trustClusterCa:
+  enabled: true
+  configMapName: overlay-castore
+  key: ca-certificates.crt
+  mountPath: /etc/ssl/certs/ca-certificates.crt
+
+# Labels put on every PersistentVolumeClaim. The cluster's backup tool uses
+# these to decide what to back up; the labels alone do nothing.
+persistentVolumeLabels:
+  hiru.io/backup: "enabled"
+
+# DMN process models, shared read-write by the API (which edits them through
+# the UI) and the Camunda worker (which executes them). Requires a
+# ReadWriteMany-capable storage class.
+processModelsStorage:
+  size: "1Gi"
+  # null means "use the cluster default". Set a string to choose one.
+  storageClassName: null
+  mountPath: /app/ProcessModels
+
+global:
+  # Image tag used when a component does not pin its own.
+  tag: "latest"
+
+  ingress:
+    enabled: true
+    className: "nginx"
+    certClusterIssuer: "ca-issuer"
+    tls: true
+
+  # Settings that more than one component needs. Defined once, here.
+  config:
+    seqUrl: "http://seq:5341"
+    logLevel: "Information"
+    # Base URL of the Keycloak that holds the Dare-TRE and Data-Egress realms.
+    treKeycloakUrl: "http://keycloak.localtest.me:8085"
+    # Base URL of the Keycloak that holds the Dare-Control realm, on the
+    # Submission side. Often a different Keycloak from the TRE one.
+    submissionKeycloakUrl: "http://keycloak.localtest.me:8085"
+    keycloakDemoMode: false
+    # Public URL of the agent API; used in onboarding data and by the UIs.
+    treApiPublicUrl: "http://agent-api.localtest.me"
+    rabbitmq:
+      host: "rabbitmq"
+      username: "rabbitmq"
+    vault:
+      url: "http://vault:8200"
+    # Zeebe gRPC gateway of the Camunda the API and worker connect to.
+    zeebeGatewayAddress: "orchestration:26500"
+    proxy:
+      enabled: false
+      url: ""
+      bypass: "agent-api,seq"
+
+# --------------------------------------------------------------------
+# One block per component. Only the settings unique to that component.
+# --------------------------------------------------------------------
+
+api:
+  enabled: true
+  image:
+    repository: harbor.federated-analytics.ac.uk/5s-tes/agent-api
+    tag: ""
+    pullPolicy: IfNotPresent
+  replicas: 1
+  # Must match the port the ASP.NET app listens on inside the container.
+  containerPort: 8080
+  resources: {}
+  service:
+    type: ClusterIP
+  secretName: agent-api-secret
+  ingress:
+    enabled: true
+    host: "agent-api.localtest.me"
+  # Address of the remote Submission API this TRE serves. An external URL,
+  # not an in-cluster name, unless both layers share a cluster.
+  submissionApiUrl: "http://submission-api.localtest.me"
+  treName: "SAIL"
+  egress:
+    apiAddress: "http://egress-api"
+    # Public URL of the Egress UI, used in token-expiry redirects.
+    uiRedirectUrl: "http://egress.localtest.me"
+  tes:
+    useTesk: true
+    apiUrl: "http://tesk.localtest.me/v1/tasks"
+    outputBucketPrefix: "s3://"
+  jobs:
+    syncSchedule: 10
+    scanSchedule: 10
+    healthCheckSchedule: 1
+    daysBeforeHealthLogDeletion: 30
+  hangfire:
+    enableExternal: true
+    username: "admin"
+  s3Tre:
+    url: "http://rustfs-tre:9002"
+    adminConsole: "http://rustfs-tre:9003"
+  s3Sub:
+    # S3 API of the Submission layer's object store; an external URL in a
+    # normal split deployment.
+    url: "http://rustfs-submission.localtest.me"
+  credentialWebhooks:
+    start: "http://connectors:8080/inbound/StartCredentials"
+    revoke: "http://connectors:8080/inbound/RevokeCredentials"
+  features:
+    seedDemoData: false
+    ephemeralCredentials: true
+  onboardingConfigImported: false
+
+ui:
+  enabled: true
+  image:
+    repository: harbor.federated-analytics.ac.uk/5s-tes/agent-ui
+    tag: ""
+    pullPolicy: IfNotPresent
+  replicas: 1
+  containerPort: 8080
+  resources: {}
+  service:
+    type: ClusterIP
+  secretName: agent-ui-secret
+  ingress:
+    enabled: true
+    host: "agent.localtest.me"
+  apiAddress: "http://agent-api"
+  uiName: "Five Safes TES"
+  sslCookies: false
+  httpsRedirect: false
+
+web:
+  enabled: true
+  image:
+    repository: harbor.federated-analytics.ac.uk/5s-tes/agent-web
+    tag: ""
+    pullPolicy: IfNotPresent
+  replicas: 1
+  containerPort: 3000
+  resources: {}
+  service:
+    type: ClusterIP
+  secretName: agent-web-secret
+  ingress:
+    enabled: true
+    host: "agent-web.localtest.me"
+  apiAddress: "http://agent-api"
+  # Public URL of this UI itself; better-auth builds callbacks from it.
+  publicUrl: "http://agent-web.localtest.me"
+  helpdeskUrl: "https://ukserp.atlassian.net/servicedesk/customer/portal/3"
+
+camundaWorker:
+  enabled: true
+  image:
+    repository: harbor.federated-analytics.ac.uk/5s-tes/credentials-camunda
+    tag: ""
+    pullPolicy: IfNotPresent
+  replicas: 1
+  resources: {}
+  secretName: agent-camunda-worker-secret
+  ldap:
+    host: "openldap"
+    port: 389
+    adminDn: "cn=admin,dc=camundaephemeral,dc=local"
+    baseDn: "dc=camundaephemeral,dc=local"
+    userOu: "ou=Users"
+    useSsl: false

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -59,7 +59,7 @@ monitoring:
 
 global:
   # Image tag used when a component does not pin its own.
-  tag: "latest"
+  tag: "3.1.1"
 
   ingress:
     enabled: true
@@ -104,7 +104,14 @@ api:
   replicas: 1
   # Must match the port the ASP.NET app listens on inside the container.
   containerPort: 8080
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+      ephemeral-storage: 256Mi
+    limits:
+      memory: 1Gi
+      ephemeral-storage: 1Gi
   service:
     type: ClusterIP
   secretName: agent-api-secret
@@ -166,7 +173,14 @@ ui:
     pullPolicy: IfNotPresent
   replicas: 1
   containerPort: 8080
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+      ephemeral-storage: 256Mi
+    limits:
+      memory: 1Gi
+      ephemeral-storage: 1Gi
   service:
     type: ClusterIP
   secretName: agent-ui-secret
@@ -189,7 +203,14 @@ web:
     pullPolicy: IfNotPresent
   replicas: 1
   containerPort: 3000
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+      ephemeral-storage: 256Mi
+    limits:
+      memory: 1Gi
+      ephemeral-storage: 1Gi
   service:
     type: ClusterIP
   secretName: agent-web-secret
@@ -210,7 +231,14 @@ camundaWorker:
     tag: ""
     pullPolicy: IfNotPresent
   replicas: 1
-  resources: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+      ephemeral-storage: 256Mi
+    limits:
+      memory: 1Gi
+      ephemeral-storage: 1Gi
   secretName: agent-camunda-worker-secret
   ldap:
     host: "openldap"


### PR DESCRIPTION
Standalone helm chart for the agent (the tre-layer), written per the Writing Helm Charts docs. Also adds the release workflow for it, and a /health endpoint to Agent.Api (copied from Submission.Api) so kubernetes has something to probe.

Four components, each with an enabled flag:

- api (agent-api)
- ui (agent-ui)
- web (agent-web)
- camunda-worker (credentials-camunda) - it runs in the tre-layer stack and we build the image, so it belongs in this chart

The env vars are lifted from the tre-layer compose file in 5S-TES-deployment rather than appsettings.json, because compose sets a bunch of things appsettings doesn't have.

api and camunda-worker share an RWX PVC at /app/ProcessModels for the DMN files, same as the shared volume in compose. Both pinned to 1 replica.

The chart doesn't create secrets, it expects them to already exist. Names and keys are in the chart README. The stack chart will create them from Vault later.


Also wires up prometheus metrics the same way serp-forms does it: prometheus-net MetricPusher in Agent.Api, Agent.Web and Credentials.Camunda, pushing to the pushgateway when PUSHGATEWAY_URL is set, with a monitoring block in the chart values. agent-web is Node so it is not covered by this.
