### PR TITLE
fix: set IsConfigurationImported when seeding data to allow auto sync

### DIFF
--- a/Agent/Agent.Api/Repositories/DbContexts/DataInitializer.cs
+++ b/Agent/Agent.Api/Repositories/DbContexts/DataInitializer.cs
@@ -1,7 +1,8 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using Agent.Api.Services;
 using FiveSafesTes.Core.Models;
 using FiveSafesTes.Core.Models.Settings;
+using FiveSafesTes.Core.Models.ViewModels;
 using FiveSafesTes.Core.Services;
 using Microsoft.Extensions.Options;
 using Serilog;
@@ -75,7 +76,10 @@ namespace Agent.Api.Repositories.DbContexts
           await _configurationService.AddConfigurationToVault(JsonSerializer.Serialize(credsToSave),
             nameof(DataEgressKeyCloakSettings));
         }
-
+        object configurationFlag = new { IsConfigurationImported = true };
+        await _configurationService.AddConfigurationToVault(JsonSerializer.Serialize(configurationFlag),
+          nameof(TreOnboardingConfig));
+        
         // Refresh configuration with new values
         await _vaultConfigProvider.LoadAsync();
       }


### PR DESCRIPTION
### :hammer_and_wrench: Pull Request
<!-- # Delete content types that don't apply to your pull request -->

🦋 Bug Fix
#### Description:
- SeedDemoData on: sets  the Submission and Egress Credentials in vault but was not setting the IsConfigurationImported flag to true. This was causing DoAgentWork to skip syncing.
- This PR sets the flag so when SeedDemoData=true then it syncs the Submission and TRE automatically
## :memo: Pre-merge checklist

Ready to merge? Do not merge until all checks are satisfied.
- [ ] :chart: Have all `required` CI checks passed on the most recent commit?
- [ ] :black_nib: Is the PR title a valid and meaningful conventional-commit message? ie. `type(scope): summary`
- [ ] :boom: Are `breaking changes` declared in the PR title in conventional-commit style? ie. `type!(scope): summary`
- [ ] :art: Does new code follow the code style of this project? 
- [ ] :mag: Has new code been spellchecked and linted?
- [ ] :book: Have docs been updated where necessary?
- [ ] :paperclip: Have commits been checked for accidental file inclusions?  
